### PR TITLE
Adds AI-powered comic generation using Hugging Face Inference and a new Manga AI page.

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,5 +16,5 @@ FRONTEND_URL=http://localhost:5173
 MAX_FILE_SIZE=10485760
 UPLOAD_DIR=./uploads
 
-# Replicate (for AI comic generation - Llama + FLUX)
-REPLICATE_API_TOKEN=r8_your-replicate-api-token
+# Hugging Face (for AI comic generation - free tier)
+HUGGINGFACE_TOKEN=your_huggingface_token_here

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,3 +15,6 @@ FRONTEND_URL=http://localhost:5173
 # File Upload
 MAX_FILE_SIZE=10485760
 UPLOAD_DIR=./uploads
+
+# Replicate (for AI comic generation - Llama + FLUX)
+REPLICATE_API_TOKEN=r8_your-replicate-api-token

--- a/backend/README.md
+++ b/backend/README.md
@@ -44,26 +44,29 @@ npm run dev
 
 ## API Endpoints
 
-### Comics
-- `GET /api/comics` - Get all user's comics
-- `POST /api/comics` - Create new comic
+### Comics (no authentication)
+
+- `GET /api/comics` - List all comics
+- `POST /api/comics` - Create comic (AI-generated). Body: `{ title, story, style?, numPanels? }`
 - `GET /api/comics/:id` - Get comic by ID
 - `PATCH /api/comics/:id` - Update comic
 - `DELETE /api/comics/:id` - Delete comic
 
-All endpoints require authentication.
+## AI Provider (Replicate)
+
+Comic generation uses Replicate:
+- **Story → panels**: `meta/meta-llama-3-8b-instruct` (splits story into panel descriptions)
+- **Panel images**: `black-forest-labs/flux-schnell` (FLUX image generation)
+
+Set `REPLICATE_API_TOKEN` in `.env` (get a token at [replicate.com/account](https://replicate.com/account)).
 
 ## Models
 
 ### Comic
 - title: string (required)
 - description: string (optional)
-- panels: array of panel objects
-- author: ObjectId (ref: User)
+- style: string (shounen | shoujo | seinen | chibi | isekai)
+- panels: array of `{ imagePath, caption?, prompt? }`
+- author: ObjectId (optional)
 - isPublic: boolean
 - tags: array of strings
-
-### User
-- email: string (required, unique)
-- password: string (required, hashed)
-- username: string (required, unique)

--- a/backend/README.md
+++ b/backend/README.md
@@ -52,13 +52,23 @@ npm run dev
 - `PATCH /api/comics/:id` - Update comic
 - `DELETE /api/comics/:id` - Delete comic
 
-## AI Provider (Replicate)
+## AI Provider (Hugging Face)
 
-Comic generation uses Replicate:
-- **Story → panels**: `meta/meta-llama-3-8b-instruct` (splits story into panel descriptions)
-- **Panel images**: `black-forest-labs/flux-schnell` (FLUX image generation)
+Comic generation uses Hugging Face Inference Providers:
+<<<<<<< Current (Your changes)
+- **Story → panels**: Chat completions via `router.huggingface.co` (SmolLM2)
+- **Panel images**: `@huggingface/inference` client (FLUX.1-schnell)
 
-Set `REPLICATE_API_TOKEN` in `.env` (get a token at [replicate.com/account](https://replicate.com/account)).
+Set `HUGGINGFACE_TOKEN` in `.env`. Create a token with "Make calls to Inference Providers" at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained).
+=======
+- **Story → panels**: Chat (Llama, Qwen, Gemma, or Mistral)
+- **Panel images**: FLUX.1-schnell
+
+**Setup:**
+1. Create a token with "Make calls to Inference Providers" at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained)
+2. **Enable providers** at [hf.co/settings/inference-providers](https://hf.co/settings/inference-providers) (e.g. Groq for free chat, or HF Inference)
+3. Set `HUGGINGFACE_TOKEN` in `.env`
+>>>>>>> Incoming (Background Agent changes)
 
 ## Models
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,20 +11,21 @@
     "test": "jest"
   },
   "dependencies": {
-    "express": "^4.18.2",
+    "@huggingface/inference": "^4.13.11",
+    "bcryptjs": "^2.4.3",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
-    "helmet": "^7.1.0",
-    "morgan": "^1.10.0",
-    "mongoose": "^8.0.3",
-    "jsonwebtoken": "^9.0.2",
-    "bcryptjs": "^2.4.3",
-    "multer": "^1.4.5-lts.1",
+    "express": "^4.18.2",
     "express-validator": "^7.0.1",
-    "compression": "^1.7.4"
+    "helmet": "^7.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.0.3",
+    "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
-    "nodemon": "^3.0.2",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0",
+    "nodemon": "^3.0.2"
   }
 }

--- a/backend/src/controllers/comicController.js
+++ b/backend/src/controllers/comicController.js
@@ -4,7 +4,7 @@ import {
   splitStoryIntoPanels,
   generateAllPanelImages,
 } from '../services/aiService.js';
-import { downloadAndSavePanelImage } from '../utils/downloadImage.js';
+import { savePanelImage } from '../utils/downloadImage.js';
 
 /**
  * Create comic. AI flow: send { title, story, style, numPanels }.
@@ -14,8 +14,8 @@ export const createComic = async (req, res, next) => {
   try {
     const { title, story, style, numPanels } = req.body;
 
-    if (!process.env.REPLICATE_API_TOKEN) {
-      throw new AppError('REPLICATE_API_TOKEN is not configured', 500);
+    if (!process.env.HUGGINGFACE_TOKEN) {
+      throw new AppError('HUGGINGFACE_TOKEN is not configured', 500);
     }
     if (!title) {
       throw new AppError('Title is required', 400);
@@ -44,7 +44,7 @@ export const createComic = async (req, res, next) => {
     const panels = [];
     for (let i = 0; i < generated.length; i++) {
       const g = generated[i];
-      const imagePath = await downloadAndSavePanelImage(g.url, comic._id, i);
+      const imagePath = await savePanelImage(g.buffer, comic._id, i);
       panels.push({
         imagePath,
         caption: g.caption || '',

--- a/backend/src/controllers/comicController.js
+++ b/backend/src/controllers/comicController.js
@@ -1,22 +1,63 @@
 import { Comic } from '../models/Comic.js';
 import { AppError } from '../middleware/errorHandler.js';
+import {
+  splitStoryIntoPanels,
+  generateAllPanelImages,
+} from '../services/aiService.js';
+import { downloadAndSavePanelImage } from '../utils/downloadImage.js';
 
+/**
+ * Create comic. AI flow: send { title, story, style, numPanels }.
+ * Manual flow: send { title, description, panels } (optional, for later).
+ */
 export const createComic = async (req, res, next) => {
   try {
-    const { title, description, panels, isPublic, tags } = req.body;
+    const { title, story, style, numPanels } = req.body;
 
+    if (!process.env.REPLICATE_API_TOKEN) {
+      throw new AppError('REPLICATE_API_TOKEN is not configured', 500);
+    }
+    if (!title) {
+      throw new AppError('Title is required', 400);
+    }
+
+    const styleKey = style || 'shounen';
+    const n = Math.min(Math.max(Number(numPanels) || 4, 2), 8);
+
+    if (!story || typeof story !== 'string' || story.trim().length === 0) {
+      throw new AppError('Story is required for AI generation', 400);
+    }
+
+    // Create comic first to get ID for image paths
     const comic = await Comic.create({
-      title,
-      description,
-      panels,
-      author: req.user?.id,
-      isPublic,
-      tags
+      title: title.trim(),
+      description: story.trim().slice(0, 500),
+      style: styleKey,
+      panels: [],
+      author: null,
+      isPublic: true,
     });
+
+    const panelDescriptions = await splitStoryIntoPanels(story.trim(), n);
+    const generated = await generateAllPanelImages(panelDescriptions, styleKey);
+
+    const panels = [];
+    for (let i = 0; i < generated.length; i++) {
+      const g = generated[i];
+      const imagePath = await downloadAndSavePanelImage(g.url, comic._id, i);
+      panels.push({
+        imagePath,
+        caption: g.caption || '',
+        prompt: g.prompt || '',
+      });
+    }
+
+    comic.panels = panels;
+    await comic.save();
 
     res.status(201).json({
       status: 'success',
-      data: comic
+      data: comic,
     });
   } catch (error) {
     next(error);
@@ -25,14 +66,14 @@ export const createComic = async (req, res, next) => {
 
 export const getComics = async (req, res, next) => {
   try {
-    const comics = await Comic.find({ author: req.user?.id })
+    const comics = await Comic.find({})
       .sort({ createdAt: -1 })
-      .populate('author', 'username email');
+      .select('-__v');
 
     res.json({
       status: 'success',
       results: comics.length,
-      data: comics
+      data: comics,
     });
   } catch (error) {
     next(error);
@@ -41,10 +82,7 @@ export const getComics = async (req, res, next) => {
 
 export const getComicById = async (req, res, next) => {
   try {
-    const comic = await Comic.findById(req.params.id).populate(
-      'author',
-      'username email'
-    );
+    const comic = await Comic.findById(req.params.id).select('-__v');
 
     if (!comic) {
       throw new AppError('Comic not found', 404);
@@ -52,7 +90,7 @@ export const getComicById = async (req, res, next) => {
 
     res.json({
       status: 'success',
-      data: comic
+      data: comic,
     });
   } catch (error) {
     next(error);
@@ -61,19 +99,20 @@ export const getComicById = async (req, res, next) => {
 
 export const updateComic = async (req, res, next) => {
   try {
-    const comic = await Comic.findOneAndUpdate(
-      { _id: req.params.id, author: req.user?.id },
+    const comic = await Comic.findByIdAndUpdate(
+      req.params.id,
       req.body,
       { new: true, runValidators: true }
-    );
+    )
+      .select('-__v');
 
     if (!comic) {
-      throw new AppError('Comic not found or unauthorized', 404);
+      throw new AppError('Comic not found', 404);
     }
 
     res.json({
       status: 'success',
-      data: comic
+      data: comic,
     });
   } catch (error) {
     next(error);
@@ -82,18 +121,15 @@ export const updateComic = async (req, res, next) => {
 
 export const deleteComic = async (req, res, next) => {
   try {
-    const comic = await Comic.findOneAndDelete({
-      _id: req.params.id,
-      author: req.user?.id
-    });
+    const comic = await Comic.findByIdAndDelete(req.params.id);
 
     if (!comic) {
-      throw new AppError('Comic not found or unauthorized', 404);
+      throw new AppError('Comic not found', 404);
     }
 
     res.status(204).json({
       status: 'success',
-      data: null
+      data: null,
     });
   } catch (error) {
     next(error);

--- a/backend/src/models/Comic.js
+++ b/backend/src/models/Comic.js
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose';
+
+const panelSchema = new mongoose.Schema(
+  {
+    imagePath: { type: String, required: true },
+    caption: { type: String, default: '' },
+    prompt: { type: String, default: '' },
+  },
+  { _id: false }
+);
+
+const comicSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    description: { type: String, default: '' },
+    style: { type: String, default: 'shounen' },
+    panels: { type: [panelSchema], default: [] },
+    author: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    isPublic: { type: Boolean, default: true },
+    tags: { type: [String], default: [] },
+  },
+  { timestamps: true }
+);
+
+export const Comic = mongoose.model('Comic', comicSchema);

--- a/backend/src/routes/comicRoutes.js
+++ b/backend/src/routes/comicRoutes.js
@@ -4,14 +4,10 @@ import {
   getComics,
   getComicById,
   updateComic,
-  deleteComic
+  deleteComic,
 } from '../controllers/comicController.js';
-import { authenticate } from '../middleware/auth.js';
 
 const router = express.Router();
-
-// All routes require authentication
-router.use(authenticate);
 
 router.route('/').get(getComics).post(createComic);
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,56 +4,50 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import compression from 'compression';
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { connectDatabase } from './config/database.js';
 import { errorHandler } from './middleware/errorHandler.js';
+import comicRoutes from './routes/comicRoutes.js';
 
-// Load environment variables
 dotenv.config();
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Middleware
 app.use(helmet());
 app.use(cors({
   origin: process.env.FRONTEND_URL || 'http://localhost:5173',
-  credentials: true
+  credentials: true,
 }));
 app.use(compression());
 app.use(morgan('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// Static files for uploads
-app.use('/uploads', express.static('uploads'));
+const uploadsDir = path.join(__dirname, '../uploads');
+app.use('/uploads', express.static(uploadsDir));
 
-// Health check
 app.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
-// API Routes
-// app.use('/api/comics', comicRoutes);
-// app.use('/api/users', userRoutes);
+app.use('/api/comics', comicRoutes);
 
-// Error handling
 app.use(errorHandler);
 
-// Start server
-// const startServer = async () => {
-//   try {
-//     await connectDatabase();
-//     app.listen(PORT, () => {
-//       console.log(`Server running on port ${PORT}`);
-//       console.log(`Environment: ${process.env.NODE_ENV}`);
-//     });
-//   } catch (error) {
-//     console.error('Failed to start server:', error);
-//     process.exit(1);
-//   }
-// };
-
-// startServer();
-app.listen(PORT, () => {
+const startServer = async () => {
+  try {
+    await connectDatabase();
+    app.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
-});
+      console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
+    });
+  } catch (err) {
+    console.error('Failed to start server:', err);
+    process.exit(1);
+  }
+};
+
+startServer();

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,9 +16,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.use(helmet());
+app.use(helmet({
+  crossOriginResourcePolicy: { policy: 'cross-origin' },
+}));
 app.use(cors({
-  origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+  origin: ['http://localhost:5173', 'http://localhost:5174', 'http://127.0.0.1:5173', 'http://127.0.0.1:5174'],
   credentials: true,
 }));
 app.use(compression());

--- a/backend/src/services/aiService.js
+++ b/backend/src/services/aiService.js
@@ -1,10 +1,9 @@
-import Replicate from 'replicate';
+import { InferenceClient } from '@huggingface/inference';
 
-function getClient() {
-  if (!process.env.REPLICATE_API_TOKEN) {
-    throw new Error('REPLICATE_API_TOKEN is not configured');
-  }
-  return new Replicate({ auth: process.env.REPLICATE_API_TOKEN });
+function getToken() {
+  const token = process.env.HUGGINGFACE_TOKEN;
+  if (!token) throw new Error('HUGGINGFACE_TOKEN is not configured');
+  return token;
 }
 
 const STYLE_PROMPTS = {
@@ -22,41 +21,95 @@ const STYLE_PROMPTS = {
     'Japanese manga style, clean lines, expressive, black and white with screen tones',
 };
 
-const LLM_MODEL = 'meta/meta-llama-3-8b-instruct';
-const IMAGE_MODEL = 'black-forest-labs/flux-schnell';
+const CHAT_MODELS = [
+  'meta-llama/Llama-3.2-3B-Instruct',
+  'Qwen/Qwen2.5-0.5B-Instruct',
+  'google/gemma-2-2b-it',
+  'mistralai/Mistral-7B-Instruct-v0.2',
+];
+const IMAGE_MODEL = 'black-forest-labs/FLUX.1-schnell';
 
 /**
- * Split a story into N panel descriptions for comic layout using Llama.
- * @param {string} story - Raw story text
- * @param {number} numPanels - Number of panels (e.g. 4 or 6)
- * @returns {Promise<string[]>} Panel description strings
+ * Call Hugging Face InferenceClient for text generation. Tries multiple models.
+ */
+async function hfText(prompt, options = {}) {
+  const token = getToken();
+  const client = new InferenceClient(token);
+  let lastError;
+  for (const model of CHAT_MODELS) {
+    try {
+      const out = await client.chatCompletion({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: options.max_new_tokens ?? 1024,
+        temperature: options.temperature ?? 0.7,
+      });
+      const text = out?.choices?.[0]?.message?.content ?? '';
+      if (text) return text;
+    } catch (err) {
+      lastError = err;
+      continue;
+    }
+  }
+  throw lastError || new Error('No chat model succeeded');
+}
+
+/**
+ * Call Hugging Face for image generation via Inference client.
+ */
+async function hfImage(prompt) {
+  const token = getToken();
+  const client = new InferenceClient(token);
+  const blob = await client.textToImage({
+    model: IMAGE_MODEL,
+    inputs: prompt.slice(0, 1000),
+  });
+  return Buffer.from(await blob.arrayBuffer());
+}
+
+/**
+ * Split a story into N panel descriptions using Hugging Face.
  */
 export async function splitStoryIntoPanels(story, numPanels) {
   const system = `You are a comic script writer. Split the user's story into exactly ${numPanels} sequential panel descriptions.
 Each description should be a single scene or moment suitable for one comic panel. Be concise (1-2 sentences each).
-Output ONLY a JSON array of ${numPanels} strings, no other text. Example: ["Scene 1...", "Scene 2...", ...]`;
+Output ONLY a valid JSON array of exactly ${numPanels} strings. Use double quotes. No markdown, no extra text.
+Example format: ["First panel scene.", "Second panel scene.", "Third panel scene."]`;
 
-  const prompt = `${system}\n\nUser story:\n${story}`;
+  const prompt = `${system}\n\nUser story:\n${story.slice(0, 1500)}`;
 
-  const replicate = getClient();
-  const output = await replicate.run(LLM_MODEL, {
-    input: {
-      prompt,
-      max_tokens: 1024,
-      temperature: 0.7,
-    },
-  });
-
-  const raw = typeof output === 'string' ? output : (output?.join?.('') ?? output?.output ?? String(output));
+  const raw = await hfText(prompt, { max_new_tokens: 512 });
   if (!raw || typeof raw !== 'string') throw new Error('No panel descriptions returned from AI');
 
   const trimmed = raw.trim();
   let arr;
+  let jsonStr = trimmed
+    .replace(/^```(?:json|javascript)?\s*/i, '')
+    .replace(/\s*```\s*$/i, '')
+    .trim();
+  const bracketMatch = jsonStr.match(/\[[\s\S]*\]/);
+  if (bracketMatch) jsonStr = bracketMatch[0];
+
   try {
-    const json = trimmed.replace(/^```json?\s*|\s*```$/g, '').trim();
-    arr = JSON.parse(json);
+    arr = JSON.parse(jsonStr);
   } catch {
-    throw new Error('Failed to parse panel descriptions as JSON');
+    // Fallback: fix common LLM issues (single quotes, trailing commas)
+    const fixed = jsonStr
+      .replace(/'/g, '"')
+      .replace(/,\s*]/g, ']')
+      .replace(/,\s*}/g, '}');
+    try {
+      arr = JSON.parse(fixed);
+    } catch {
+      // Last resort: extract quoted strings from array-like structure
+      const stringMatches = jsonStr.matchAll(/"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'/g);
+      const extracted = [...stringMatches].map((m) => (m[1] ?? m[2] ?? '').replace(/\\"/g, '"').trim()).filter(Boolean);
+      if (extracted.length >= numPanels) {
+        arr = extracted.slice(0, numPanels);
+      } else {
+        throw new Error('Failed to parse panel descriptions as JSON');
+      }
+    }
   }
 
   if (!Array.isArray(arr) || arr.length !== numPanels) {
@@ -67,34 +120,27 @@ Output ONLY a JSON array of ${numPanels} strings, no other text. Example: ["Scen
 }
 
 /**
- * Generate a single comic panel image via FLUX Schnell.
- * @param {string} panelDescription - Scene description for this panel
- * @param {string} styleKey - Style key (e.g. shounen, shoujo)
- * @returns {Promise<{ url: string }>}
+ * Generate a single comic panel image. Returns image buffer (not URL).
  */
 export async function generatePanelImage(panelDescription, styleKey) {
   const stylePrompt = STYLE_PROMPTS[styleKey] || STYLE_PROMPTS.default;
   const prompt = `Single vertical comic panel, ${stylePrompt}. Scene: ${panelDescription}. No text or speech bubbles in the image.`;
-
-  const replicate = getClient();
-  const output = await replicate.run(IMAGE_MODEL, {
-    input: { prompt: prompt.slice(0, 1000) },
-  });
-
-  const first = Array.isArray(output) ? output[0] : output;
-  const url = typeof first?.url === 'function' ? first.url() : first?.url ?? first;
-  if (!url) throw new Error('No image URL returned from Replicate');
-  return { url };
+  const buffer = await hfImage(prompt);
+  return { buffer };
 }
 
 /**
- * Generate images for all panels. Runs sequentially to avoid rate limits.
+ * Generate images for all panels. Returns array of { buffer, caption, prompt }.
  */
 export async function generateAllPanelImages(panelDescriptions, styleKey) {
   const results = [];
   for (let i = 0; i < panelDescriptions.length; i++) {
-    const { url } = await generatePanelImage(panelDescriptions[i], styleKey);
-    results.push({ url, caption: panelDescriptions[i], prompt: panelDescriptions[i] });
+    const { buffer } = await generatePanelImage(panelDescriptions[i], styleKey);
+    results.push({
+      buffer,
+      caption: panelDescriptions[i],
+      prompt: panelDescriptions[i],
+    });
   }
   return results;
 }

--- a/backend/src/services/aiService.js
+++ b/backend/src/services/aiService.js
@@ -1,0 +1,100 @@
+import Replicate from 'replicate';
+
+function getClient() {
+  if (!process.env.REPLICATE_API_TOKEN) {
+    throw new Error('REPLICATE_API_TOKEN is not configured');
+  }
+  return new Replicate({ auth: process.env.REPLICATE_API_TOKEN });
+}
+
+const STYLE_PROMPTS = {
+  shounen:
+    'Japanese shounen manga style, dynamic action, bold lines, dramatic angles, black and white with screen tones',
+  shoujo:
+    'Japanese shoujo manga style, romantic, soft lines, sparkles, expressive eyes, black and white with screen tones',
+  seinen:
+    'Japanese seinen manga style, mature, detailed, realistic proportions, gritty, black and white with screen tones',
+  chibi:
+    'Chibi manga style, cute proportions, big head, small body, kawaii, black and white with screen tones',
+  isekai:
+    'Isekai fantasy manga style, otherworldly, magic, adventurers, black and white with screen tones',
+  default:
+    'Japanese manga style, clean lines, expressive, black and white with screen tones',
+};
+
+const LLM_MODEL = 'meta/meta-llama-3-8b-instruct';
+const IMAGE_MODEL = 'black-forest-labs/flux-schnell';
+
+/**
+ * Split a story into N panel descriptions for comic layout using Llama.
+ * @param {string} story - Raw story text
+ * @param {number} numPanels - Number of panels (e.g. 4 or 6)
+ * @returns {Promise<string[]>} Panel description strings
+ */
+export async function splitStoryIntoPanels(story, numPanels) {
+  const system = `You are a comic script writer. Split the user's story into exactly ${numPanels} sequential panel descriptions.
+Each description should be a single scene or moment suitable for one comic panel. Be concise (1-2 sentences each).
+Output ONLY a JSON array of ${numPanels} strings, no other text. Example: ["Scene 1...", "Scene 2...", ...]`;
+
+  const prompt = `${system}\n\nUser story:\n${story}`;
+
+  const replicate = getClient();
+  const output = await replicate.run(LLM_MODEL, {
+    input: {
+      prompt,
+      max_tokens: 1024,
+      temperature: 0.7,
+    },
+  });
+
+  const raw = typeof output === 'string' ? output : (output?.join?.('') ?? output?.output ?? String(output));
+  if (!raw || typeof raw !== 'string') throw new Error('No panel descriptions returned from AI');
+
+  const trimmed = raw.trim();
+  let arr;
+  try {
+    const json = trimmed.replace(/^```json?\s*|\s*```$/g, '').trim();
+    arr = JSON.parse(json);
+  } catch {
+    throw new Error('Failed to parse panel descriptions as JSON');
+  }
+
+  if (!Array.isArray(arr) || arr.length !== numPanels) {
+    throw new Error(`Expected ${numPanels} panel descriptions, got ${arr?.length ?? 0}`);
+  }
+
+  return arr.map((s) => String(s).trim()).filter(Boolean);
+}
+
+/**
+ * Generate a single comic panel image via FLUX Schnell.
+ * @param {string} panelDescription - Scene description for this panel
+ * @param {string} styleKey - Style key (e.g. shounen, shoujo)
+ * @returns {Promise<{ url: string }>}
+ */
+export async function generatePanelImage(panelDescription, styleKey) {
+  const stylePrompt = STYLE_PROMPTS[styleKey] || STYLE_PROMPTS.default;
+  const prompt = `Single vertical comic panel, ${stylePrompt}. Scene: ${panelDescription}. No text or speech bubbles in the image.`;
+
+  const replicate = getClient();
+  const output = await replicate.run(IMAGE_MODEL, {
+    input: { prompt: prompt.slice(0, 1000) },
+  });
+
+  const first = Array.isArray(output) ? output[0] : output;
+  const url = typeof first?.url === 'function' ? first.url() : first?.url ?? first;
+  if (!url) throw new Error('No image URL returned from Replicate');
+  return { url };
+}
+
+/**
+ * Generate images for all panels. Runs sequentially to avoid rate limits.
+ */
+export async function generateAllPanelImages(panelDescriptions, styleKey) {
+  const results = [];
+  for (let i = 0; i < panelDescriptions.length; i++) {
+    const { url } = await generatePanelImage(panelDescriptions[i], styleKey);
+    results.push({ url, caption: panelDescriptions[i], prompt: panelDescriptions[i] });
+  }
+  return results;
+}

--- a/backend/src/utils/downloadImage.js
+++ b/backend/src/utils/downloadImage.js
@@ -1,0 +1,29 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const UPLOADS_ROOT = path.join(__dirname, '../../uploads');
+
+/**
+ * Download image from URL and save to uploads/comics/:comicId/panel-:index.png
+ * @param {string} imageUrl - Source URL
+ * @param {string} comicId - Comic document ID
+ * @param {number} index - Panel index
+ * @returns {Promise<string>} Relative path like "comics/:comicId/panel-0.png"
+ */
+export async function downloadAndSavePanelImage(imageUrl, comicId, index) {
+  const dir = path.join(UPLOADS_ROOT, 'comics', String(comicId));
+  await fs.mkdir(dir, { recursive: true });
+
+  const basename = `panel-${index}.png`;
+  const filePath = path.join(dir, basename);
+  const relativePath = path.join('comics', String(comicId), basename).replace(/\\/g, '/');
+
+  const res = await fetch(imageUrl);
+  if (!res.ok) throw new Error(`Failed to fetch image: ${res.status}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  await fs.writeFile(filePath, buf);
+
+  return relativePath;
+}

--- a/backend/src/utils/downloadImage.js
+++ b/backend/src/utils/downloadImage.js
@@ -6,13 +6,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const UPLOADS_ROOT = path.join(__dirname, '../../uploads');
 
 /**
- * Download image from URL and save to uploads/comics/:comicId/panel-:index.png
- * @param {string} imageUrl - Source URL
+ * Save image buffer to uploads/comics/:comicId/panel-:index.png
+ * @param {Buffer} buffer - Image bytes
  * @param {string} comicId - Comic document ID
  * @param {number} index - Panel index
  * @returns {Promise<string>} Relative path like "comics/:comicId/panel-0.png"
  */
-export async function downloadAndSavePanelImage(imageUrl, comicId, index) {
+export async function savePanelImage(buffer, comicId, index) {
   const dir = path.join(UPLOADS_ROOT, 'comics', String(comicId));
   await fs.mkdir(dir, { recursive: true });
 
@@ -20,10 +20,6 @@ export async function downloadAndSavePanelImage(imageUrl, comicId, index) {
   const filePath = path.join(dir, basename);
   const relativePath = path.join('comics', String(comicId), basename).replace(/\\/g, '/');
 
-  const res = await fetch(imageUrl);
-  if (!res.ok) throw new Error(`Failed to fetch image: ${res.status}`);
-  const buf = Buffer.from(await res.arrayBuffer());
-  await fs.writeFile(filePath, buf);
-
+  await fs.writeFile(filePath, buffer);
   return relativePath;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@400;500;700;900&display=swap" rel="stylesheet" />
     <title>Comic Generator</title>
   </head>
   <body>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,10 +4,12 @@ import HomePage from './pages/HomePage';
 import ComicsPage from './pages/ComicsPage';
 import CreateComicPage from './pages/CreateComicPage';
 import ComicDetailPage from './pages/ComicDetailPage';
+import MangaAIPage from './pages/MangaAIPage';
 
 function App() {
   return (
     <Routes>
+      <Route path="/manga-ai" element={<MangaAIPage />} />
       <Route path="/" element={<Layout />}>
         <Route index element={<HomePage />} />
         <Route path="comics" element={<ComicsPage />} />

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -21,13 +21,19 @@ const Layout = () => {
                   to="/comics"
                   className="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
                 >
-                  My Comics
+                  Comics
                 </Link>
                 <Link
                   to="/comics/create"
                   className="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
                 >
                   Create
+                </Link>
+                <Link
+                  to="/manga-ai"
+                  className="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+                >
+                  Manga AI
                 </Link>
               </div>
             </div>

--- a/frontend/src/pages/ComicDetailPage.jsx
+++ b/frontend/src/pages/ComicDetailPage.jsx
@@ -1,17 +1,89 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api, uploadsUrl } from '../services/api';
 
-const ComicDetailPage = () => {
+export default function ComicDetailPage() {
   const { id } = useParams();
+  const [comic, setComic] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchComic() {
+      try {
+        const { data } = await api.get(`/comics/${id}`);
+        if (!cancelled) setComic(data.data);
+      } catch (err) {
+        if (!cancelled) setError(err.response?.data?.message || err.message || 'Failed to load comic.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    if (id) fetchComic();
+    return () => { cancelled = true; };
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <div className="flex justify-center py-12">
+          <p className="text-gray-500">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !comic) {
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <div className="rounded-lg bg-red-50 p-4 text-red-700 mb-4">
+          {error || 'Comic not found.'}
+        </div>
+        <Link to="/comics" className="text-blue-600 hover:text-blue-700 font-medium">
+          ← Back to comics
+        </Link>
+      </div>
+    );
+  }
 
   return (
     <div className="px-4 py-6 sm:px-0">
-      <h2 className="text-2xl font-bold text-gray-900 mb-6">Comic Details</h2>
-      <div className="bg-white shadow rounded-lg p-6">
-        <p className="text-gray-500">Comic ID: {id}</p>
-        {/* Comic details will be loaded here */}
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">{comic.title}</h2>
+          <p className="text-gray-500 mt-1">
+            {comic.style} · {comic.panels?.length ?? 0} panels
+          </p>
+        </div>
+        <Link
+          to="/comics"
+          className="text-gray-600 hover:text-gray-900 font-medium"
+        >
+          ← Back to comics
+        </Link>
+      </div>
+      {comic.description && (
+        <p className="text-gray-600 mb-8 max-w-2xl">{comic.description}</p>
+      )}
+      <div className="bg-white rounded-lg shadow overflow-hidden">
+        <div className="divide-y divide-gray-100">
+          {(comic.panels || []).map((panel, i) => (
+            <div key={i} className="p-4 sm:p-6">
+              <div className="max-w-2xl mx-auto">
+                <img
+                  src={uploadsUrl(panel.imagePath)}
+                  alt={panel.caption || `Panel ${i + 1}`}
+                  className="w-full rounded-lg border border-gray-200"
+                />
+                {panel.caption && (
+                  <p className="mt-2 text-sm text-gray-500 italic">{panel.caption}</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );
-};
-
-export default ComicDetailPage;
+}

--- a/frontend/src/pages/ComicsPage.jsx
+++ b/frontend/src/pages/ComicsPage.jsx
@@ -1,15 +1,92 @@
-const ComicsPage = () => {
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api, uploadsUrl } from '../services/api';
+
+export default function ComicsPage() {
+  const [comics, setComics] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchComics() {
+      try {
+        const { data } = await api.get('/comics');
+        if (!cancelled) setComics(data.data || []);
+      } catch (err) {
+        if (!cancelled) setError(err.response?.data?.message || err.message || 'Failed to load comics.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    fetchComics();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <h2 className="text-2xl font-bold text-gray-900 mb-6">Comics</h2>
+        <div className="flex justify-center py-12">
+          <p className="text-gray-500">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <h2 className="text-2xl font-bold text-gray-900 mb-6">Comics</h2>
+        <div className="rounded-lg bg-red-50 p-4 text-red-700">{error}</div>
+      </div>
+    );
+  }
+
   return (
     <div className="px-4 py-6 sm:px-0">
-      <h2 className="text-2xl font-bold text-gray-900 mb-6">My Comics</h2>
+      <h2 className="text-2xl font-bold text-gray-900 mb-6">Comics</h2>
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {/* Comics will be loaded here */}
-        <div className="text-center py-12 col-span-full">
-          <p className="text-gray-500">No comics yet. Create your first comic!</p>
-        </div>
+        {comics.length === 0 ? (
+          <div className="col-span-full text-center py-12">
+            <p className="text-gray-500 mb-4">No comics yet.</p>
+            <Link
+              to="/comics/create"
+              className="text-blue-600 hover:text-blue-700 font-medium"
+            >
+              Create your first comic →
+            </Link>
+          </div>
+        ) : (
+          comics.map((c) => (
+            <Link
+              key={c._id}
+              to={`/comics/${c._id}`}
+              className="group block bg-white rounded-lg shadow overflow-hidden hover:shadow-md transition"
+            >
+              <div className="aspect-[3/4] bg-gray-100 flex items-center justify-center">
+                {c.panels?.[0]?.imagePath ? (
+                  <img
+                    src={uploadsUrl(c.panels[0].imagePath)}
+                    alt=""
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <span className="text-4xl text-gray-400">📖</span>
+                )}
+              </div>
+              <div className="p-4">
+                <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 truncate">
+                  {c.title}
+                </h3>
+                <p className="text-sm text-gray-500 mt-1">
+                  {c.style} · {c.panels?.length ?? 0} panels
+                </p>
+              </div>
+            </Link>
+          ))
+        )}
       </div>
     </div>
   );
-};
-
-export default ComicsPage;
+}

--- a/frontend/src/pages/CreateComicPage.jsx
+++ b/frontend/src/pages/CreateComicPage.jsx
@@ -1,9 +1,62 @@
-const CreateComicPage = () => {
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../services/api';
+
+const STYLES = [
+  { value: 'shounen', label: 'Shounen', desc: 'Action, adventure, bold' },
+  { value: 'shoujo', label: 'Shoujo', desc: 'Romance, soft, expressive' },
+  { value: 'seinen', label: 'Seinen', desc: 'Mature, detailed, gritty' },
+  { value: 'chibi', label: 'Chibi', desc: 'Cute, kawaii' },
+  { value: 'isekai', label: 'Isekai', desc: 'Fantasy, otherworldly' },
+];
+
+const PANEL_OPTS = [2, 4, 6, 8];
+
+export default function CreateComicPage() {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [story, setStory] = useState('');
+  const [style, setStyle] = useState('shounen');
+  const [numPanels, setNumPanels] = useState(4);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError('');
+    if (!title.trim()) {
+      setError('Please enter a title.');
+      return;
+    }
+    if (!story.trim()) {
+      setError('Please enter a story for the AI to illustrate.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const { data } = await api.post('/comics', {
+        title: title.trim(),
+        story: story.trim(),
+        style,
+        numPanels,
+      });
+      navigate(`/comics/${data.data._id}`);
+    } catch (err) {
+      const msg = err.response?.data?.message || err.message || 'Failed to create comic.';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <div className="px-4 py-6 sm:px-0">
-      <h2 className="text-2xl font-bold text-gray-900 mb-6">Create New Comic</h2>
-      <div className="bg-white shadow rounded-lg p-6">
-        <form>
+      <h2 className="text-2xl font-bold text-gray-900 mb-2">Create Comic with AI</h2>
+      <p className="text-gray-500 mb-6">
+        Describe your story. AI will split it into panels and generate manga-style art.
+      </p>
+      <div className="bg-white shadow rounded-lg p-6 max-w-2xl">
+        <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
               Title
@@ -11,33 +64,87 @@ const CreateComicPage = () => {
             <input
               type="text"
               id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Enter comic title"
+              placeholder="e.g. The Last Samurai"
+              disabled={loading}
             />
           </div>
           <div className="mb-4">
-            <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-2">
-              Description
+            <label htmlFor="story" className="block text-sm font-medium text-gray-700 mb-2">
+              Story
             </label>
             <textarea
-              id="description"
-              rows={3}
+              id="story"
+              rows={6}
+              value={story}
+              onChange={(e) => setStory(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Enter comic description"
+              placeholder="Write your story or scene descriptions. The AI will turn them into comic panels."
+              disabled={loading}
             />
           </div>
-          <div className="flex justify-end">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+            <div>
+              <label htmlFor="style" className="block text-sm font-medium text-gray-700 mb-2">
+                Style
+              </label>
+              <select
+                id="style"
+                value={style}
+                onChange={(e) => setStyle(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                disabled={loading}
+              >
+                {STYLES.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label} — {s.desc}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="panels" className="block text-sm font-medium text-gray-700 mb-2">
+                Panels
+              </label>
+              <select
+                id="panels"
+                value={numPanels}
+                onChange={(e) => setNumPanels(Number(e.target.value))}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                disabled={loading}
+              >
+                {PANEL_OPTS.map((n) => (
+                  <option key={n} value={n}>
+                    {n} panels
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {error && (
+            <div className="mb-4 p-3 rounded-md bg-red-50 text-red-700 text-sm">{error}</div>
+          )}
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              disabled={loading}
+            >
+              Cancel
+            </button>
             <button
               type="submit"
-              className="px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              disabled={loading}
+              className="px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              Create Comic
+              {loading ? 'Generating…' : 'Generate comic'}
             </button>
           </div>
         </form>
       </div>
     </div>
   );
-};
-
-export default CreateComicPage;
+}

--- a/frontend/src/pages/MangaAIPage.jsx
+++ b/frontend/src/pages/MangaAIPage.jsx
@@ -1,0 +1,392 @@
+import { Link } from 'react-router-dom';
+
+const NAV_LINKS = [
+  { label: 'Start Creating', href: '#create' },
+  { label: 'View Examples', href: '#gallery' },
+];
+
+const BADGES = [
+  'Free Trial',
+  '14 Manga Genres',
+  'HD Export',
+];
+
+const GENRE_CHIPS = [
+  { emoji: '⚔️', label: 'Shounen' },
+  { emoji: '🌸', label: 'Shoujo' },
+  { emoji: '🎭', label: 'Seinen' },
+  { emoji: '✨', label: 'Isekai' },
+  { emoji: '🍥', label: 'Chibi' },
+];
+
+const CREATION_METHODS = [
+  {
+    title: 'Upload Your Characters',
+    description:
+      'Have photos of people or character designs? Upload them and our AI will transform them into manga characters, maintaining their unique features across all panels in authentic manga style.',
+    bullets: ['Perfect for OC manga', 'Manga-style expressions', 'Consistent character design'],
+    cta: 'Upload Characters',
+  },
+  {
+    title: 'Describe Your Story',
+    description:
+      "Just type your story or scene descriptions, and AI will generate everything - characters, backgrounds, and action sequences in authentic manga style.",
+    bullets: ['Authentic manga panels', 'AI-designed characters', 'No images needed'],
+    cta: 'Write Your Story',
+  },
+];
+
+const EXAMPLE_MANGA = [
+  { title: 'Demon Blade Chronicles', genre: 'Shounen Battle', style: 'Shounen', panels: 7 },
+  { title: 'Sakura First Love', genre: 'School Romance', style: 'Shoujo', panels: 4 },
+  { title: 'Tokyo Noir', genre: 'Mystery Thriller', style: 'Seinen', panels: 7 },
+  { title: 'Reborn as a Slime', genre: 'Isekai Fantasy', style: 'Isekai', panels: 6 },
+  { title: 'Café Memories', genre: 'Slice of Life', style: 'Josei', panels: 4 },
+  { title: 'Mecha Genesis', genre: 'Sci-Fi Action', style: 'Mecha', panels: 6 },
+];
+
+const STYLES = [
+  { emoji: '⚔️', label: 'Shounen' },
+  { emoji: '🌸', label: 'Shoujo' },
+  { emoji: '🎭', label: 'Seinen' },
+  { emoji: '🌹', label: 'Josei' },
+  { emoji: '🌟', label: 'Kodomo' },
+  { emoji: '🍥', label: 'Chibi' },
+  { emoji: '✨', label: 'Isekai' },
+  { emoji: '🤖', label: 'Mecha' },
+  { emoji: '☕', label: 'Slice of Life' },
+  { emoji: '👻', label: 'Horror' },
+  { emoji: '⚽', label: 'Sports' },
+  { emoji: '💕', label: 'Romance' },
+];
+
+const USE_CASES = [
+  { title: 'Aspiring Mangaka', desc: 'Bring your manga dreams to life without years of art training.' },
+  { title: 'Light Novel Authors', desc: 'Visualize your light novel scenes and create manga adaptations.' },
+  { title: 'Anime Fans', desc: 'Create original manga stories inspired by your favorite genres and styles.' },
+  { title: 'Content Creators', desc: 'Make manga-style content for social media and YouTube.' },
+];
+
+const FEATURES = [
+  { title: 'Authentic Manga AI', desc: 'AI trained on manga art to create authentic Japanese-style illustrations.' },
+  { title: 'Character Consistency', desc: 'Characters maintain their unique design across all panels and pages.' },
+  { title: 'Panel Layouts', desc: 'Traditional manga panel layouts and compositions.' },
+  { title: 'Speed Lines & Effects', desc: 'Automatic manga effects like speed lines, screen tones, and SFX.' },
+];
+
+const STEPS = [
+  { n: 1, title: 'Choose Input', desc: 'Upload character designs or describe your story in text.' },
+  { n: 2, title: 'Select Manga Style', desc: 'Pick from shounen, shoujo, seinen, and more authentic styles.' },
+  { n: 3, title: 'Customize Panels', desc: 'Choose panel layouts and manga-specific effects.' },
+  { n: 4, title: 'Download & Share', desc: 'Get high-resolution manga pages ready for publishing.' },
+];
+
+const STATS = [
+  { value: 'Worldwide', label: 'Manga Created' },
+  { value: '12 Styles', label: 'Available' },
+  { value: '60-90 sec', label: 'Generation Time' },
+];
+
+export default function MangaAIPage() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 font-zen">
+      {/* Nav */}
+      <nav className="sticky top-0 z-50 border-b border-slate-800 bg-slate-950/90 backdrop-blur">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link to="/manga-ai" className="text-xl font-bold tracking-tight">
+              Manga AI
+            </Link>
+            <div className="flex items-center gap-4">
+              {NAV_LINKS.map(({ label, href }) => (
+                <a
+                  key={label}
+                  href={href}
+                  className="text-sm text-slate-400 hover:text-white transition"
+                >
+                  {label}
+                </a>
+              ))}
+              <a
+                href="#create"
+                className="rounded-full bg-rose-500 px-4 py-2 text-sm font-medium text-white hover:bg-rose-600 transition"
+              >
+                Try Free — No Payment Required
+              </a>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      {/* Hero */}
+      <section className="relative overflow-hidden pt-16 pb-24 sm:pt-24 sm:pb-32">
+        <div className="absolute inset-0 bg-gradient-to-b from-rose-950/20 via-transparent to-transparent" />
+        <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-rose-400/90 text-sm font-medium uppercase tracking-wider mb-4">
+            Your Story, Illustrated in Manga Style
+          </p>
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight max-w-4xl mx-auto leading-tight">
+            Turn Your Ideas Into Authentic Manga — Zero Art Skills Required
+          </h1>
+          <p className="mt-6 text-lg sm:text-xl text-slate-400 max-w-2xl mx-auto">
+            Transform stories into manga pages instantly. Upload character references or describe scenes
+            in text, pick from shounen, shoujo, seinen aesthetics, and let AI craft your vision with
+            authentic Japanese style.
+          </p>
+          <div className="mt-10 flex flex-wrap justify-center gap-4">
+            <a
+              href="#create"
+              className="rounded-full bg-rose-500 px-6 py-3 text-base font-semibold text-white hover:bg-rose-600 transition"
+            >
+              Start Creating
+            </a>
+            <a
+              href="#gallery"
+              className="rounded-full border border-slate-600 px-6 py-3 text-base font-medium text-slate-300 hover:border-slate-500 hover:text-white transition"
+            >
+              View Examples
+            </a>
+          </div>
+          <div className="mt-12 flex flex-wrap justify-center gap-6 text-slate-500 text-sm">
+            {BADGES.map((b) => (
+              <span key={b} className="flex items-center gap-2">
+                <span className="h-1.5 w-1.5 rounded-full bg-rose-500" />
+                {b}
+              </span>
+            ))}
+          </div>
+          <div className="mt-10 flex flex-wrap justify-center gap-2">
+            {GENRE_CHIPS.map(({ emoji, label }) => (
+              <span
+                key={label}
+                className="rounded-full border border-slate-700 bg-slate-900/50 px-4 py-2 text-sm text-slate-300"
+              >
+                {emoji} {label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Two Ways to Create */}
+      <section id="create" className="py-20 border-t border-slate-800">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold text-center mb-4">Two Ways to Create Your Manga</h2>
+          <p className="text-slate-400 text-center max-w-2xl mx-auto mb-16">
+            Choose the creation method that works best for your manga story
+          </p>
+          <div className="grid md:grid-cols-2 gap-8">
+            {CREATION_METHODS.map((m) => (
+              <div
+                key={m.title}
+                className="rounded-2xl border border-slate-800 bg-slate-900/50 p-8 hover:border-slate-700 transition"
+              >
+                <h3 className="text-xl font-bold mb-4">{m.title}</h3>
+                <p className="text-slate-400 mb-6">{m.description}</p>
+                <ul className="space-y-2 mb-8">
+                  {m.bullets.map((b) => (
+                    <li key={b} className="flex items-center gap-2 text-slate-300">
+                      <span className="text-rose-500">•</span> {b}
+                    </li>
+                  ))}
+                </ul>
+                <a
+                  href="#create"
+                  className="inline-block rounded-full bg-rose-500 px-5 py-2.5 text-sm font-medium text-white hover:bg-rose-600 transition"
+                >
+                  {m.cta}
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Gallery */}
+      <section id="gallery" className="py-20 border-t border-slate-800 bg-slate-900/30">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold text-center mb-4">Manga Created with Manga AI</h2>
+          <p className="text-slate-400 text-center mb-12">
+            From action-packed shounen to heartfelt shoujo — see what&apos;s possible
+          </p>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {EXAMPLE_MANGA.map((m) => (
+              <div
+                key={m.title}
+                className="group rounded-2xl border border-slate-800 bg-slate-900/50 overflow-hidden hover:border-slate-600 transition"
+              >
+                <div className="aspect-[3/4] bg-gradient-to-br from-slate-800 to-slate-900 flex items-center justify-center">
+                  <span className="text-6xl opacity-50 group-hover:opacity-70 transition">📖</span>
+                </div>
+                <div className="p-4">
+                  <h3 className="font-bold text-lg">{m.title}</h3>
+                  <p className="text-slate-500 text-sm">{m.genre}</p>
+                  <div className="mt-2 flex gap-2 text-xs text-slate-400">
+                    <span>{m.style}</span>
+                    <span>•</span>
+                    <span>{m.panels} panels</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-10 text-center">
+            <a
+              href="#gallery"
+              className="text-rose-400 hover:text-rose-300 font-medium"
+            >
+              View Full Manga Gallery →
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Choose Your Manga Style */}
+      <section className="py-20 border-t border-slate-800">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold text-center mb-4">Choose Your Manga Style</h2>
+          <p className="text-slate-400 text-center mb-12">
+            Authentic manga art styles for every type of story
+          </p>
+          <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-4">
+            {STYLES.map((s) => (
+              <a
+                key={s.label}
+                href="#create"
+                className="flex flex-col items-center rounded-xl border border-slate-800 bg-slate-900/50 p-6 hover:border-rose-500/50 hover:bg-slate-800/50 transition"
+              >
+                <span className="text-3xl mb-2">{s.emoji}</span>
+                <span className="text-sm font-medium text-slate-300">{s.label}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Perfect For */}
+      <section className="py-20 border-t border-slate-800 bg-slate-900/30">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold text-center mb-4">Perfect For Every Manga Creator</h2>
+          <p className="text-slate-400 text-center mb-12">
+            From aspiring mangaka to seasoned artists — Manga AI empowers everyone
+          </p>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {USE_CASES.map((u) => (
+              <div
+                key={u.title}
+                className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6"
+              >
+                <h3 className="font-bold text-lg mb-2">{u.title}</h3>
+                <p className="text-slate-400 text-sm">{u.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose */}
+      <section className="py-20 border-t border-slate-800">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold text-center mb-4">Why Choose Manga AI?</h2>
+          <p className="text-slate-400 text-center mb-12">
+            Professional manga creation made simple
+          </p>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {FEATURES.map((f) => (
+              <div
+                key={f.title}
+                className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6"
+              >
+                <h3 className="font-bold text-lg mb-2">{f.title}</h3>
+                <p className="text-slate-400 text-sm">{f.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 4 Steps */}
+      <section className="py-20 border-t border-slate-800 bg-slate-900/30">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold text-center mb-4">Create Your Manga in 4 Simple Steps</h2>
+          <p className="text-slate-400 text-center mb-12">
+            Begin with complimentary credits — no payment info needed
+          </p>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            {STEPS.map((s) => (
+              <div key={s.n} className="relative">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-rose-500 text-lg font-bold text-white mb-4">
+                  {s.n}
+                </div>
+                <h3 className="font-bold text-lg mb-2">{s.title}</h3>
+                <p className="text-slate-400 text-sm">{s.desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-12 text-center">
+            <a
+              href="#create"
+              className="inline-block rounded-full bg-rose-500 px-8 py-4 text-base font-semibold text-white hover:bg-rose-600 transition"
+            >
+              Start Creating Manga Now →
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="py-24 border-t border-slate-800">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-rose-400/90 text-sm font-medium uppercase tracking-wider mb-4">
+            Complimentary Credits — No Payment Needed
+          </p>
+          <h2 className="text-3xl sm:text-4xl font-bold mb-6">
+            Ready to Become a Manga Creator?
+          </h2>
+          <p className="text-slate-400 text-lg mb-10">
+            Join the community of storytellers bringing their visions to life. Try free today —
+            artistic talent not required.
+          </p>
+          <div className="flex flex-wrap justify-center gap-8 mb-10 text-center">
+            {STATS.map((s) => (
+              <div key={s.label}>
+                <div className="text-2xl font-bold text-white">{s.value}</div>
+                <div className="text-slate-500 text-sm">{s.label}</div>
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-wrap justify-center gap-4">
+            <a
+              href="#create"
+              className="rounded-full bg-rose-500 px-8 py-4 text-base font-semibold text-white hover:bg-rose-600 transition"
+            >
+              Start Creating Now
+            </a>
+            <a
+              href="#gallery"
+              className="rounded-full border border-slate-600 px-8 py-4 text-base font-medium text-slate-300 hover:border-slate-500 hover:text-white transition"
+            >
+              Browse Gallery
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="py-12 border-t border-slate-800">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-wrap justify-center gap-8 text-slate-500 text-sm">
+            <span>Try Before You Buy</span>
+            <span>60-90 Second Generation</span>
+            <span>High-Res Export</span>
+          </div>
+          <div className="mt-6 text-center">
+            <Link to="/" className="text-slate-500 hover:text-slate-400 text-sm">
+              ← Back to Comic Generator
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 export const api = axios.create({
   baseURL: `${API_URL}/api`,
@@ -9,30 +9,16 @@ export const api = axios.create({
   },
 });
 
-// Request interceptor to add auth token
-api.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-// Response interceptor to handle errors
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      localStorage.removeItem('token');
-      window.location.href = '/login';
-    }
-    return Promise.reject(error);
-  }
+  (error) => Promise.reject(error)
 );
+
+/** Full URL for an uploaded asset (e.g. comic panel imagePath). */
+export function uploadsUrl(relativePath) {
+  const base = API_URL.replace(/\/$/, '');
+  const p = (relativePath || '').replace(/^\//, '');
+  return `${base}/uploads/${p}`;
+}
 
 export default api;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,7 +5,11 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        zen: ['"Zen Kaku Gothic New"', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Changes

### Backend
- **AI provider**: Switched from Replicate to Hugging Face Inference
  - **Text**: Chat completion with fallback models (Llama, Qwen, Gemma, Mistral) to split stories into panel descriptions
  - **Images**: FLUX.1-schnell for panel image generation
- **JSON parsing**: More robust parsing for LLM panel descriptions (markdown stripping, single-quote fix, regex fallback)
- **CORS**: Helmet `crossOriginResourcePolicy: 'cross-origin'` so panel images load when frontend and backend run on different ports
- **Config**: `HUGGINGFACE_TOKEN` in `.env.example` and README setup instructions

### Frontend
- **Manga AI page** (`/manga-ai`): New UI-only page
- **CreateComicPage**: AI flow with story input, style selection, and panel count
- **ComicDetailPage / ComicsPage**: Display and list AI-generated comics with panel images

### Setup
- Requires `HUGGINGFACE_TOKEN` in `backend/.env`
- At least one Inference provider enabled at [hf.co/settings/inference-providers](https://hf.co/settings/inference-providers) (e.g. Groq, HF Inference)

## Testing
- [x] Create comic from story
- [x] Panel images load on detail page
- [x] Comics list and detail pages work