### PR TITLE
AI manga generator: full UI refresh, page-turn carousel, narration/scene panel split

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,5 +16,15 @@ FRONTEND_URL=http://localhost:5173
 MAX_FILE_SIZE=10485760
 UPLOAD_DIR=./uploads
 
-# Hugging Face (for AI comic generation - free tier)
+# Hugging Face Inference (see backend README)
 HUGGINGFACE_TOKEN=your_huggingface_token_here
+# Set to 0 to skip chat entirely and split the story locally into panels (still need HF for images unless you change that too)
+# HF_PANELS_CHAT=0
+# Optional: if you enabled a provider at https://hf.co/settings/inference-providers (e.g. groq)
+# HF_CHAT_PROVIDER=groq
+# Optional: force one image model / provider (otherwise the server tries several)
+# HF_IMAGE_MODEL=stabilityai/stable-diffusion-2-1
+# HF_IMAGE_PROVIDER=
+# For FLUX, you often need a third-party provider, e.g.:
+# HF_IMAGE_MODEL=black-forest-labs/FLUX.1-schnell
+# HF_IMAGE_PROVIDER=fal-ai

--- a/backend/README.md
+++ b/backend/README.md
@@ -54,14 +54,33 @@ npm run dev
 
 ## AI Provider (Hugging Face)
 
-Comic generation uses Hugging Face Inference Providers:
-- **Story → panels**: Chat (Llama, Qwen, Gemma, or Mistral)
-- **Panel images**: FLUX.1-schnell
+Comic generation uses the Hugging Face router (`@huggingface/inference`):
+
+- **Story → panels**: chat completion (tries several small instruct models; optional `HF_CHAT_PROVIDER` such as `groq` if enabled on your account)
+- **Panel images**: tries, in order, `HF_IMAGE_MODEL` if set, then common Stable Diffusion checkpoints on HF Inference, then **FLUX.1-schnell** via `fal-ai` and `replicate` if your token has those providers enabled
 
 **Setup:**
-1. Create a token with "Make calls to Inference Providers" at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained)
-2. **Enable providers** at [hf.co/settings/inference-providers](https://hf.co/settings/inference-providers) (e.g. Groq for free chat, or HF Inference)
+
+1. Create a token with inference permissions at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained)
+2. **Enable inference providers** at [hf.co/settings/inference-providers](https://hf.co/settings/inference-providers) (chat: e.g. Groq; images: HF serverless and/or fal-ai for FLUX)
 3. Set `HUGGINGFACE_TOKEN` in `.env`
+
+If you see *“Failed to perform inference: an HTTP error occurred when requesting the provider”*, the router could not complete the call (token, provider not enabled, rate limit, or model not available). Set `HF_IMAGE_MODEL=stabilityai/stable-diffusion-2-1` to prefer a widely available image model, or configure `HF_IMAGE_PROVIDER` (e.g. `fal-ai`) for FLUX—see `.env.example`.
+
+### Chat (story → panels) fails for every model
+
+1. **Use the app anyway:** the server **falls back automatically** to a local split (by sentences or character chunks) if all chat models error. You still need a working **image** model for panel art.
+2. **Fix Hugging Face chat:** create a [fine-grained token](https://huggingface.co/settings/tokens) with **Make calls to Inference Providers** (and read access if required). Open [Inference Providers](https://hf.co/settings/inference-providers) and enable at least one provider that serves chat (e.g. **Groq**). Then in `.env` add `HF_CHAT_PROVIDER=groq` and restart the backend.
+3. **Skip chat on purpose:** set `HF_PANELS_CHAT=0` to always use the local splitter (no chat API calls).
+
+### Quick checklist
+
+| Check | Action |
+|--------|--------|
+| Token type | Fine-grained with Inference / Inference Providers permissions |
+| Providers | Enabled at hf.co/settings/inference-providers for the models you use |
+| Chat | Optional `HF_CHAT_PROVIDER=groq` after enabling Groq |
+| Images | Optional `HF_IMAGE_MODEL` / `HF_IMAGE_PROVIDER` if defaults fail |
 
 ## Models
 

--- a/backend/src/controllers/comicController.js
+++ b/backend/src/controllers/comicController.js
@@ -38,8 +38,12 @@ export const createComic = async (req, res, next) => {
       isPublic: true,
     });
 
-    const panelDescriptions = await splitStoryIntoPanels(story.trim(), n);
-    const generated = await generateAllPanelImages(panelDescriptions, styleKey);
+    const trimmedStory = story.trim();
+    const panelDescriptions = await splitStoryIntoPanels(trimmedStory, n);
+    const generated = await generateAllPanelImages(panelDescriptions, styleKey, {
+      title: title.trim(),
+      story: trimmedStory,
+    });
 
     const panels = [];
     for (let i = 0; i < generated.length; i++) {

--- a/backend/src/services/aiService.js
+++ b/backend/src/services/aiService.js
@@ -27,22 +27,57 @@ const CHAT_MODELS = [
   'google/gemma-2-2b-it',
   'mistralai/Mistral-7B-Instruct-v0.2',
 ];
-const IMAGE_MODEL = 'black-forest-labs/FLUX.1-schnell';
 
-/**
- * Call Hugging Face InferenceClient for text generation. Tries multiple models.
- */
+function buildImageAttempts() {
+  const attempts = [];
+  const seen = new Set();
+  const add = (model, provider) => {
+    const key = `${model}||${provider || ''}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    attempts.push({ model, provider: provider || undefined });
+  };
+
+  if (process.env.HF_IMAGE_MODEL) {
+    add(process.env.HF_IMAGE_MODEL, process.env.HF_IMAGE_PROVIDER || undefined);
+  }
+
+  add('stabilityai/stable-diffusion-2-1');
+  add('runwayml/stable-diffusion-v1-5');
+  add('stabilityai/stable-diffusion-xl-base-1.0');
+  add('black-forest-labs/FLUX.1-schnell', 'fal-ai');
+  add('black-forest-labs/FLUX.1-schnell', 'replicate');
+
+  return attempts;
+}
+
+function formatInferenceError(lastErr, step, triedLabels) {
+  const detail = lastErr?.message || String(lastErr);
+  let message = `Failed during ${step}: ${detail}`;
+  if (triedLabels.length) {
+    message += ` [attempted: ${triedLabels.join(', ')}]`;
+  }
+  message +=
+    ' — Check HUGGINGFACE_TOKEN (fine-grained: Inference / Inference Providers), enable providers at https://hf.co/settings/inference-providers, and see backend README. Optional: HF_CHAT_PROVIDER (e.g. groq), HF_IMAGE_MODEL, HF_IMAGE_PROVIDER (e.g. fal-ai for FLUX).';
+  return new Error(message);
+}
+
 async function hfText(prompt, options = {}) {
   const token = getToken();
   const client = new InferenceClient(token);
+  const provider = process.env.HF_CHAT_PROVIDER || undefined;
   let lastError;
+  const tried = [];
+
   for (const model of CHAT_MODELS) {
+    tried.push(model + (provider ? ` (${provider})` : ''));
     try {
       const out = await client.chatCompletion({
         model,
         messages: [{ role: 'user', content: prompt }],
         max_tokens: options.max_new_tokens ?? 1024,
         temperature: options.temperature ?? 0.7,
+        ...(provider ? { provider } : {}),
       });
       const text = out?.choices?.[0]?.message?.content ?? '';
       if (text) return text;
@@ -51,34 +86,111 @@ async function hfText(prompt, options = {}) {
       continue;
     }
   }
-  throw lastError || new Error('No chat model succeeded');
+  throw formatInferenceError(lastError || new Error('No chat model succeeded'), 'story → panels (chat)', tried);
 }
 
-/**
- * Call Hugging Face for image generation via Inference client.
- */
 async function hfImage(prompt) {
   const token = getToken();
   const client = new InferenceClient(token);
-  const blob = await client.textToImage({
-    model: IMAGE_MODEL,
-    inputs: prompt.slice(0, 1000),
-  });
-  return Buffer.from(await blob.arrayBuffer());
+  const input = prompt.slice(0, 1500);
+  const attempts = buildImageAttempts();
+  let lastErr;
+  const triedLabels = [];
+
+  for (const { model, provider } of attempts) {
+    triedLabels.push(provider ? `${model}@${provider}` : model);
+    try {
+      const blob = await client.textToImage({
+        model,
+        inputs: input,
+        ...(provider ? { provider } : {}),
+      });
+      return Buffer.from(await blob.arrayBuffer());
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+
+  throw formatInferenceError(lastErr || new Error('No image model succeeded'), 'panel image (text-to-image)', triedLabels);
 }
 
 /**
- * Split a story into N panel descriptions using Hugging Face.
+ * Split source text into N text segments, never breaking mid-sentence; distributes whole
+ * sentences across panels and falls back to clause splits if there are too few sentences.
+ * Returns an array of N strings (raw segments only — narration polishing happens elsewhere).
  */
-export async function splitStoryIntoPanels(story, numPanels) {
-  const system = `You are a comic script writer. Split the user's story into exactly ${numPanels} sequential panel descriptions.
-Each description should be a single scene or moment suitable for one comic panel. Be concise (1-2 sentences each).
-Output ONLY a valid JSON array of exactly ${numPanels} strings. Use double quotes. No markdown, no extra text.
-Example format: ["First panel scene.", "Second panel scene.", "Third panel scene."]`;
+function chunkStoryIntoSegments(story, numPanels) {
+  const text = String(story || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\s+/g, ' ')
+    .trim();
 
-  const prompt = `${system}\n\nUser story:\n${story.slice(0, 1500)}`;
+  if (!text) {
+    return Array.from({ length: numPanels }, (_, i) => `Panel ${i + 1}.`);
+  }
 
-  const raw = await hfText(prompt, { max_new_tokens: 512 });
+  let units = text
+    .split(/(?<=[.!?…])\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (units.length < numPanels) {
+    const expanded = [];
+    for (const sentence of units) {
+      const parts = sentence
+        .split(/(?:[,;:]| (?:and|then|but|so|after|before|while|because|when|until)\s)/i)
+        .map((p) => p.trim())
+        .filter(Boolean);
+      if (parts.length <= 1) {
+        expanded.push(sentence);
+      } else {
+        expanded.push(...parts);
+      }
+    }
+    if (expanded.length > units.length) units = expanded;
+  }
+
+  while (units.length < numPanels) {
+    units.push(units[units.length - 1] || text);
+  }
+
+  const out = [];
+  for (let p = 0; p < numPanels; p++) {
+    const start = Math.round((p * units.length) / numPanels);
+    const end = Math.round(((p + 1) * units.length) / numPanels);
+    const slice = units.slice(start, Math.max(end, start + 1));
+    let part = slice.join(' ').trim();
+    if (!/[.!?…]$/.test(part)) part += '.';
+    out.push(part);
+  }
+  return out;
+}
+
+/**
+ * Heuristic split into panels with both narration (story prose) and scene (visual description).
+ * Used when the chat call fails or is disabled. narration === scene here because we have no LLM
+ * to rewrite the source into vivid visual cues, so we let the original prose serve both purposes.
+ */
+export function splitStoryIntoPanelsHeuristic(story, numPanels) {
+  const segments = chunkStoryIntoSegments(story, numPanels);
+  return segments.map((seg) => ({ narration: seg, scene: seg }));
+}
+
+async function splitStoryIntoPanelsWithChat(story, numPanels) {
+  const system = `You are a comic book writer and storyboard artist. Read the user's story and break it into exactly ${numPanels} sequential comic panels.
+
+For each panel, produce TWO things:
+1. "narration": 2-3 sentences of vivid storybook prose narrating this panel's moment. Use past tense and a consistent narrative voice. Read together in order, all ${numPanels} narrations must form ONE continuous, cohesive story that covers the user's story end-to-end with no gaps and no repetition. Each panel's narration should pick up from where the previous one left off.
+2. "scene": 1-2 sentences describing what to DRAW in this single panel — the setting, time of day, which characters are present (carry over the same names and look every panel), the specific action shown, and the mood. This is for an image generator, not for the reader.
+
+Cover the entire story. Do not invent content beyond what the user wrote. Do not cut a sentence in half across panels.
+
+Output ONLY a valid JSON array of exactly ${numPanels} objects with keys "narration" and "scene". Use double quotes. No markdown, no commentary.
+Example: [{"narration":"Akira gripped the hilt of his katana, breath fogging in the cold dawn air.","scene":"Close-up of Akira, a teenage boy with spiky black hair and a red headband, drawing his katana in a snowy bamboo grove at sunrise, dramatic backlighting, tense mood."}]`;
+
+  const prompt = `${system}\n\nUser story:\n${story.slice(0, 2000)}`;
+
+  const raw = await hfText(prompt, { max_new_tokens: 1400 });
   if (!raw || typeof raw !== 'string') throw new Error('No panel descriptions returned from AI');
 
   const trimmed = raw.trim();
@@ -93,53 +205,119 @@ Example format: ["First panel scene.", "Second panel scene.", "Third panel scene
   try {
     arr = JSON.parse(jsonStr);
   } catch {
-    // Fallback: fix common LLM issues (single quotes, trailing commas)
     const fixed = jsonStr
       .replace(/'/g, '"')
       .replace(/,\s*]/g, ']')
       .replace(/,\s*}/g, '}');
-    try {
-      arr = JSON.parse(fixed);
-    } catch {
-      // Last resort: extract quoted strings from array-like structure
-      const stringMatches = jsonStr.matchAll(/"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'/g);
-      const extracted = [...stringMatches].map((m) => (m[1] ?? m[2] ?? '').replace(/\\"/g, '"').trim()).filter(Boolean);
-      if (extracted.length >= numPanels) {
-        arr = extracted.slice(0, numPanels);
-      } else {
-        throw new Error('Failed to parse panel descriptions as JSON');
-      }
-    }
+    arr = JSON.parse(fixed);
   }
 
   if (!Array.isArray(arr) || arr.length !== numPanels) {
-    throw new Error(`Expected ${numPanels} panel descriptions, got ${arr?.length ?? 0}`);
+    throw new Error(`Expected ${numPanels} panel objects, got ${arr?.length ?? 0}`);
   }
 
-  return arr.map((s) => String(s).trim()).filter(Boolean);
+  // Normalize: tolerate models that return strings instead of {narration, scene}.
+  return arr.map((item, i) => {
+    if (typeof item === 'string') {
+      const s = item.trim();
+      return { narration: s, scene: s };
+    }
+    const narration = String(item?.narration ?? item?.caption ?? item?.text ?? '').trim();
+    const scene = String(item?.scene ?? item?.description ?? item?.image ?? narration).trim();
+    if (!narration && !scene) {
+      throw new Error(`Panel ${i + 1} is missing both narration and scene`);
+    }
+    return { narration: narration || scene, scene: scene || narration };
+  });
 }
 
 /**
- * Generate a single comic panel image. Returns image buffer (not URL).
+ * Split a story into N panels. Each entry is { narration, scene }.
+ * - narration: storybook prose shown to the reader under the panel image.
+ * - scene: visual description fed to the image generator (hidden from reader).
+ * Tries Hugging Face chat first; on failure (or HF_PANELS_CHAT=0), uses a local heuristic
+ * where narration === scene === the user's original prose for that panel.
  */
-export async function generatePanelImage(panelDescription, styleKey) {
+export async function splitStoryIntoPanels(story, numPanels) {
+  const chatEnabled = process.env.HF_PANELS_CHAT !== '0';
+  if (chatEnabled) {
+    try {
+      return await splitStoryIntoPanelsWithChat(story, numPanels);
+    } catch (err) {
+      console.warn('[aiService] Chat panel split failed; using heuristic panels:', err.message);
+    }
+  }
+  return splitStoryIntoPanelsHeuristic(story, numPanels);
+}
+
+/**
+ * Compose the image prompt for a single panel using the comic title, style, and a short
+ * recap of the surrounding story so the model has consistent context per panel.
+ */
+function buildPanelImagePrompt({ scene, panelIndex, totalPanels, styleKey, title, storyExcerpt }) {
   const stylePrompt = STYLE_PROMPTS[styleKey] || STYLE_PROMPTS.default;
-  const prompt = `Single vertical comic panel, ${stylePrompt}. Scene: ${panelDescription}. No text or speech bubbles in the image.`;
-  const buffer = await hfImage(prompt);
-  return { buffer };
+  const titleLine = title ? `Comic title: "${title}".` : '';
+  const positionLine = `Panel ${panelIndex + 1} of ${totalPanels}.`;
+  const contextLine = storyExcerpt ? `Overall story context: ${storyExcerpt}` : '';
+  const sceneLine = `Scene to draw in this panel: ${scene}`;
+
+  return [
+    `Single vertical comic panel, ${stylePrompt}.`,
+    titleLine,
+    positionLine,
+    contextLine,
+    sceneLine,
+    'Keep characters consistent with previous panels in this comic.',
+    'No text, no speech bubbles, no captions, no watermarks in the image.',
+  ]
+    .filter(Boolean)
+    .join(' ');
 }
 
 /**
- * Generate images for all panels. Returns array of { buffer, caption, prompt }.
+ * Generate a single comic panel image. `panel` is { narration, scene } from splitStoryIntoPanels.
+ * Returns { buffer, prompt } where `prompt` is the full text-to-image prompt actually sent.
  */
-export async function generateAllPanelImages(panelDescriptions, styleKey) {
+export async function generatePanelImage(panel, styleKey, ctx = {}) {
+  const scene = typeof panel === 'string' ? panel : panel?.scene || panel?.narration || '';
+  const prompt = buildPanelImagePrompt({
+    scene,
+    panelIndex: ctx.panelIndex ?? 0,
+    totalPanels: ctx.totalPanels ?? 1,
+    styleKey,
+    title: ctx.title,
+    storyExcerpt: ctx.storyExcerpt,
+  });
+  const buffer = await hfImage(prompt);
+  return { buffer, prompt };
+}
+
+/**
+ * Generate images for every panel. `panels` is an array of { narration, scene }.
+ * Returns array of { buffer, caption, prompt } where:
+ *   - caption = narration (storybook prose shown to the reader)
+ *   - prompt  = the full text-to-image prompt (hidden from the reader)
+ */
+export async function generateAllPanelImages(panels, styleKey, ctx = {}) {
+  const total = panels.length;
+  const storyExcerpt = ctx.story
+    ? String(ctx.story).replace(/\s+/g, ' ').trim().slice(0, 400)
+    : '';
   const results = [];
-  for (let i = 0; i < panelDescriptions.length; i++) {
-    const { buffer } = await generatePanelImage(panelDescriptions[i], styleKey);
+  for (let i = 0; i < total; i++) {
+    const panel = panels[i];
+    const narration =
+      typeof panel === 'string' ? panel : panel?.narration || panel?.scene || '';
+    const { buffer, prompt } = await generatePanelImage(panel, styleKey, {
+      title: ctx.title,
+      panelIndex: i,
+      totalPanels: total,
+      storyExcerpt,
+    });
     results.push({
       buffer,
-      caption: panelDescriptions[i],
-      prompt: panelDescriptions[i],
+      caption: narration,
+      prompt,
     });
   }
   return results;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import Layout from './components/Layout';
 import HomePage from './pages/HomePage';
 import ComicsPage from './pages/ComicsPage';
@@ -9,9 +9,10 @@ import MangaAIPage from './pages/MangaAIPage';
 function App() {
   return (
     <Routes>
-      <Route path="/manga-ai" element={<MangaAIPage />} />
       <Route path="/" element={<Layout />}>
         <Route index element={<HomePage />} />
+        <Route path="guide" element={<MangaAIPage />} />
+        <Route path="manga-ai" element={<Navigate to="/guide" replace />} />
         <Route path="comics" element={<ComicsPage />} />
         <Route path="comics/create" element={<CreateComicPage />} />
         <Route path="comics/:id" element={<ComicDetailPage />} />

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,48 +1,44 @@
-import { Outlet, Link } from 'react-router-dom';
+import { Outlet, NavLink, Link } from 'react-router-dom';
+
+const navClass = ({ isActive }) =>
+  [
+    'inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium transition-colors',
+    isActive
+      ? 'border-blue-600 text-gray-900'
+      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+  ].join(' ');
 
 const Layout = () => {
   return (
     <div className="min-h-screen bg-gray-50">
-      <nav className="bg-white shadow-sm">
+      <nav className="border-b border-gray-200 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
             <div className="flex">
               <Link to="/" className="flex-shrink-0 flex items-center">
-                <h1 className="text-xl font-bold text-gray-900">Comic Generator</h1>
+                <span className="text-xl font-bold text-gray-900 tracking-tight">Comic Generator</span>
               </Link>
-              <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
-                <Link
-                  to="/"
-                  className="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                >
+              <div className="hidden sm:ml-8 sm:flex sm:gap-6">
+                <NavLink to="/" end className={navClass}>
                   Home
-                </Link>
-                <Link
-                  to="/comics"
-                  className="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                >
+                </NavLink>
+                <NavLink to="/comics" className={navClass}>
                   Comics
-                </Link>
-                <Link
-                  to="/comics/create"
-                  className="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                >
+                </NavLink>
+                <NavLink to="/comics/create" className={navClass}>
                   Create
-                </Link>
-                <Link
-                  to="/manga-ai"
-                  className="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                >
+                </NavLink>
+                <NavLink to="/manga-ai" className={navClass}>
                   Manga AI
-                </Link>
+                </NavLink>
               </div>
             </div>
           </div>
         </div>
       </nav>
 
-      <main>
-        <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+      <main className="min-h-[calc(100vh-4rem)]">
+        <div className="max-w-5xl mx-auto py-8 sm:px-6 lg:px-8">
           <Outlet />
         </div>
       </main>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,35 +1,50 @@
-import { Outlet, NavLink, Link } from 'react-router-dom';
+import { Outlet, NavLink, Link, useLocation } from 'react-router-dom';
 
 const navClass = ({ isActive }) =>
   [
     'inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium transition-colors',
     isActive
-      ? 'border-blue-600 text-gray-900'
-      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+      ? 'border-indigo-600 text-gray-900'
+      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-800',
   ].join(' ');
 
 const Layout = () => {
+  const location = useLocation();
+  const onCreate =
+    location.pathname === '/comics/create' || location.pathname.startsWith('/comics/create/');
+
+  // Comics highlights for /comics and /comics/:id, but not for /comics/create.
+  const comicsClass = ({ isActive }) => navClass({ isActive: isActive && !onCreate });
+
   return (
-    <div className="min-h-screen bg-gray-50">
-      <nav className="border-b border-gray-200 bg-white">
+    <div className="min-h-screen">
+      <nav className="sticky top-0 z-40 border-b border-white/60 bg-white/80 backdrop-blur shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
             <div className="flex">
-              <Link to="/" className="flex-shrink-0 flex items-center">
-                <span className="text-xl font-bold text-gray-900 tracking-tight">Comic Generator</span>
+              <Link to="/" className="flex-shrink-0 flex items-center gap-2">
+                <span
+                  aria-hidden
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-600 via-violet-600 to-rose-500 text-white shadow"
+                >
+                  <span className="text-sm font-extrabold">C</span>
+                </span>
+                <span className="text-lg sm:text-xl font-bold text-gray-900 tracking-tight">
+                  Comic Generator
+                </span>
               </Link>
               <div className="hidden sm:ml-8 sm:flex sm:gap-6">
                 <NavLink to="/" end className={navClass}>
                   Home
                 </NavLink>
-                <NavLink to="/comics" className={navClass}>
+                <NavLink to="/comics" className={comicsClass}>
                   Comics
                 </NavLink>
                 <NavLink to="/comics/create" className={navClass}>
                   Create
                 </NavLink>
-                <NavLink to="/manga-ai" className={navClass}>
-                  Manga AI
+                <NavLink to="/guide" className={navClass}>
+                  Guide
                 </NavLink>
               </div>
             </div>

--- a/frontend/src/components/PageShell.jsx
+++ b/frontend/src/components/PageShell.jsx
@@ -1,0 +1,28 @@
+/**
+ * Shared page header + width wrapper for a clear content outline.
+ */
+export default function PageShell({ eyebrow, title, description, actions, children }) {
+  return (
+    <div className="px-4 py-6 sm:px-0">
+      <header className="mb-8 max-w-3xl border-b border-gray-200 pb-6">
+        {eyebrow ? (
+          <p className="text-xs font-semibold uppercase tracking-wider text-blue-700 mb-2">
+            {eyebrow}
+          </p>
+        ) : null}
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">
+              {title}
+            </h1>
+            {description ? (
+              <p className="mt-2 text-gray-600 leading-relaxed">{description}</p>
+            ) : null}
+          </div>
+          {actions ? <div className="flex flex-wrap items-center gap-2 shrink-0">{actions}</div> : null}
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/PageShell.jsx
+++ b/frontend/src/components/PageShell.jsx
@@ -1,17 +1,22 @@
 /**
- * Shared page header + width wrapper for a clear content outline.
+ * Shared page header + width wrapper. Adds a colored accent strip
+ * so pages do not feel like a wall of white.
  */
 export default function PageShell({ eyebrow, title, description, actions, children }) {
   return (
     <div className="px-4 py-6 sm:px-0">
-      <header className="mb-8 max-w-3xl border-b border-gray-200 pb-6">
-        {eyebrow ? (
-          <p className="text-xs font-semibold uppercase tracking-wider text-blue-700 mb-2">
-            {eyebrow}
-          </p>
-        ) : null}
+      <header className="relative mb-8 overflow-hidden rounded-2xl border border-white/70 bg-white/80 p-6 sm:p-8 shadow-sm backdrop-blur">
+        <div
+          aria-hidden
+          className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-indigo-500 via-violet-500 to-rose-500"
+        />
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="min-w-0">
+          <div className="min-w-0 max-w-3xl">
+            {eyebrow ? (
+              <p className="text-xs font-semibold uppercase tracking-wider text-indigo-700 mb-2">
+                {eyebrow}
+              </p>
+            ) : null}
             <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">
               {title}
             </h1>
@@ -19,7 +24,9 @@ export default function PageShell({ eyebrow, title, description, actions, childr
               <p className="mt-2 text-gray-600 leading-relaxed">{description}</p>
             ) : null}
           </div>
-          {actions ? <div className="flex flex-wrap items-center gap-2 shrink-0">{actions}</div> : null}
+          {actions ? (
+            <div className="flex flex-wrap items-center gap-2 shrink-0">{actions}</div>
+          ) : null}
         </div>
       </header>
       {children}

--- a/frontend/src/components/SectionBlock.jsx
+++ b/frontend/src/components/SectionBlock.jsx
@@ -9,10 +9,10 @@ export default function SectionBlock({ id, title, description, children, classNa
     <section
       id={id}
       aria-labelledby={title ? headingId : undefined}
-      className={`rounded-xl border border-gray-200 bg-white shadow-sm ${className}`}
+      className={`rounded-xl border border-white/70 bg-white shadow-sm ${className}`}
     >
       {(title || description) && (
-        <div className="border-b border-gray-100 px-5 py-4 sm:px-6">
+        <div className="border-b border-gray-100 px-5 py-4 sm:px-6 bg-gradient-to-r from-indigo-50/60 to-transparent">
           {title ? (
             <h2 id={headingId} className="text-lg font-semibold text-gray-900">
               {title}

--- a/frontend/src/components/SectionBlock.jsx
+++ b/frontend/src/components/SectionBlock.jsx
@@ -1,0 +1,27 @@
+import { useId } from 'react';
+
+/**
+ * Bordered section with optional title for scannable layouts.
+ */
+export default function SectionBlock({ id, title, description, children, className = '' }) {
+  const headingId = useId();
+  return (
+    <section
+      id={id}
+      aria-labelledby={title ? headingId : undefined}
+      className={`rounded-xl border border-gray-200 bg-white shadow-sm ${className}`}
+    >
+      {(title || description) && (
+        <div className="border-b border-gray-100 px-5 py-4 sm:px-6">
+          {title ? (
+            <h2 id={headingId} className="text-lg font-semibold text-gray-900">
+              {title}
+            </h2>
+          ) : null}
+          {description ? <p className="mt-1 text-sm text-gray-600 leading-relaxed">{description}</p> : null}
+        </div>
+      )}
+      <div className="p-5 sm:p-6">{children}</div>
+    </section>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,8 +7,8 @@
   line-height: 1.5;
   font-weight: 400;
   color-scheme: light;
-  color: #111827;
-  background-color: #f9fafb;
+  color: #0f172a;
+  background-color: #f5f3ff;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -19,6 +19,69 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  color: #111827;
-  background-color: #f9fafb;
+  color: #0f172a;
+  background:
+    radial-gradient(1200px 600px at 0% -10%, rgba(99, 102, 241, 0.18), transparent 60%),
+    radial-gradient(900px 500px at 100% 0%, rgba(244, 114, 182, 0.15), transparent 55%),
+    linear-gradient(180deg, #f8fafc 0%, #eef2ff 60%, #fdf2f8 100%);
+  background-attachment: fixed;
+}
+
+/* ---------- Book page-turn animation (used in ComicDetailPage carousel) ---------- */
+.page-stage {
+  perspective: 1800px;
+  transform-style: preserve-3d;
+}
+
+.page-turn-forward {
+  animation: page-turn-forward 600ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  transform-origin: left center;
+  backface-visibility: hidden;
+  will-change: transform, opacity, box-shadow;
+}
+
+.page-turn-backward {
+  animation: page-turn-backward 600ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  transform-origin: right center;
+  backface-visibility: hidden;
+  will-change: transform, opacity, box-shadow;
+}
+
+@keyframes page-turn-forward {
+  0% {
+    opacity: 0;
+    transform: rotateY(75deg) translateX(35%);
+    box-shadow: -30px 10px 40px -10px rgba(15, 23, 42, 0.35);
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+    transform: rotateY(0) translateX(0);
+    box-shadow: 0 1px 2px 0 rgba(15, 23, 42, 0.05);
+  }
+}
+
+@keyframes page-turn-backward {
+  0% {
+    opacity: 0;
+    transform: rotateY(-75deg) translateX(-35%);
+    box-shadow: 30px 10px 40px -10px rgba(15, 23, 42, 0.35);
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+    transform: rotateY(0) translateX(0);
+    box-shadow: 0 1px 2px 0 rgba(15, 23, 42, 0.05);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-turn-forward,
+  .page-turn-backward {
+    animation: none;
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,11 +6,9 @@
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color-scheme: light;
+  color: #111827;
+  background-color: #f9fafb;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -21,4 +19,6 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  color: #111827;
+  background-color: #f9fafb;
 }

--- a/frontend/src/pages/ComicDetailPage.jsx
+++ b/frontend/src/pages/ComicDetailPage.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import { api, uploadsUrl } from '../services/api';
 import PageShell from '../components/PageShell';
 
@@ -17,16 +17,26 @@ function formatDate(iso) {
 
 export default function ComicDetailPage() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const [comic, setComic] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [index, setIndex] = useState(0);
+  // 'forward' | 'backward' — drives which page-turn keyframe plays
+  const [direction, setDirection] = useState('forward');
+  // Bumped on every turn so the page node remounts and the CSS animation replays
+  const [turnTick, setTurnTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     async function fetchComic() {
       try {
         const { data } = await api.get(`/comics/${id}`);
-        if (!cancelled) setComic(data.data);
+        if (!cancelled) {
+          setComic(data.data);
+          setIndex(0);
+        }
       } catch (err) {
         if (!cancelled) setError(err.response?.data?.message || err.message || 'Failed to load comic.');
       } finally {
@@ -39,10 +49,63 @@ export default function ComicDetailPage() {
     };
   }, [id]);
 
+  const panels = comic?.panels || [];
+  const panelCount = panels.length;
+
+  const turnTo = useCallback(
+    (target, dir) => {
+      if (!panelCount) return;
+      const next = ((target % panelCount) + panelCount) % panelCount;
+      setDirection(dir);
+      setIndex(next);
+      setTurnTick((t) => t + 1);
+    },
+    [panelCount]
+  );
+
+  const goPrev = useCallback(() => {
+    if (!panelCount) return;
+    turnTo(index - 1, 'backward');
+  }, [index, panelCount, turnTo]);
+
+  const goNext = useCallback(() => {
+    if (!panelCount) return;
+    turnTo(index + 1, 'forward');
+  }, [index, panelCount, turnTo]);
+
+  useEffect(() => {
+    if (!panelCount) return undefined;
+    const onKey = (e) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        goPrev();
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        goNext();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [panelCount, goPrev, goNext]);
+
+  async function handleDelete() {
+    if (!comic) return;
+    const ok = window.confirm(`Delete "${comic.title}"? This cannot be undone.`);
+    if (!ok) return;
+    setDeleting(true);
+    try {
+      await api.delete(`/comics/${comic._id}`);
+      navigate('/comics', { replace: true });
+    } catch (err) {
+      setError(err.response?.data?.message || err.message || 'Failed to delete comic.');
+      setDeleting(false);
+    }
+  }
+
   if (loading) {
     return (
       <PageShell eyebrow="Comic" title="Loading…" description="Fetching panels and metadata.">
-        <div className="flex justify-center py-16 rounded-xl border border-gray-200 bg-white">
+        <div className="flex justify-center py-16 rounded-xl border border-white/70 bg-white/80 backdrop-blur shadow-sm">
           <p className="text-gray-500 text-sm">Loading…</p>
         </div>
       </PageShell>
@@ -55,108 +118,192 @@ export default function ComicDetailPage() {
         <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-800 text-sm mb-4">
           {error || 'Comic not found.'}
         </div>
-        <Link to="/comics" className="text-blue-600 hover:text-blue-700 font-medium text-sm">
+        <Link to="/comics" className="text-indigo-700 hover:text-indigo-900 font-medium text-sm">
           ← Back to comics
         </Link>
       </PageShell>
     );
   }
 
-  const panelCount = comic.panels?.length ?? 0;
   const created = formatDate(comic.createdAt);
+  const current = panels[index];
+  const safeIndex = panelCount ? Math.min(index, panelCount - 1) : 0;
 
   return (
     <PageShell
       eyebrow="Comic"
       title={comic.title}
-      description="Summary and panels in order. Captions appear under each image when the model provided them."
+      description="Use the left and right arrows (or keyboard ← →) to step through panels."
       actions={
-        <Link
-          to="/comics"
-          className="text-sm font-medium text-gray-600 hover:text-gray-900"
-        >
-          ← Back to comics
-        </Link>
+        <>
+          <Link
+            to="/comics"
+            className="inline-flex items-center px-3 py-2 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50"
+          >
+            ← Back
+          </Link>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="inline-flex items-center px-3 py-2 rounded-lg text-sm font-semibold text-white bg-rose-600 hover:bg-rose-700 disabled:opacity-60 disabled:cursor-not-allowed shadow-sm"
+          >
+            {deleting ? 'Deleting…' : 'Delete comic'}
+          </button>
+        </>
       }
     >
-      <div className="space-y-8 max-w-3xl">
-        <section
-          aria-labelledby="meta-heading"
-          className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden"
-        >
-          <h2 id="meta-heading" className="sr-only">
-            Comic details
+      <article className="relative max-w-3xl rounded-2xl border border-white/70 bg-white shadow-sm overflow-hidden">
+        <div
+          aria-hidden
+          className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-indigo-500 via-violet-500 to-rose-500"
+        />
+
+        <header className="px-6 sm:px-8 pt-8 pb-6 bg-gradient-to-b from-indigo-50/70 to-white">
+          <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">
+            {comic.title}
           </h2>
-          <dl className="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-100">
-            <div className="px-5 py-4">
-              <dt className="text-xs font-semibold uppercase tracking-wider text-gray-500">Style</dt>
-              <dd className="mt-1 text-sm font-medium text-gray-900 capitalize">{comic.style}</dd>
+          <dl className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            <div className="flex items-center gap-2">
+              <dt className="text-gray-500">Style</dt>
+              <dd className="font-medium text-gray-900 capitalize">{comic.style}</dd>
             </div>
-            <div className="px-5 py-4">
-              <dt className="text-xs font-semibold uppercase tracking-wider text-gray-500">Panels</dt>
-              <dd className="mt-1 text-sm font-medium text-gray-900">{panelCount}</dd>
+            <div className="flex items-center gap-2">
+              <dt className="text-gray-500">Panels</dt>
+              <dd className="font-medium text-gray-900">{panelCount}</dd>
             </div>
-            <div className="px-5 py-4">
-              <dt className="text-xs font-semibold uppercase tracking-wider text-gray-500">Created</dt>
-              <dd className="mt-1 text-sm font-medium text-gray-900">{created || '—'}</dd>
+            <div className="flex items-center gap-2">
+              <dt className="text-gray-500">Created</dt>
+              <dd className="font-medium text-gray-900">{created || '—'}</dd>
             </div>
           </dl>
           {comic.description ? (
-            <div className="px-5 py-4 border-t border-gray-100">
-              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
-                Story summary
-              </h3>
-              <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">{comic.description}</p>
-            </div>
+            <p className="mt-5 text-sm text-gray-700 leading-relaxed whitespace-pre-wrap max-w-2xl">
+              {comic.description}
+            </p>
           ) : null}
-        </section>
+        </header>
 
-        <section aria-labelledby="panels-heading">
-          <h2 id="panels-heading" className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">
-            Panels ({panelCount})
-          </h2>
-          <ol className="space-y-6 list-none p-0 m-0">
-            {(comic.panels || []).map((panel, i) => (
-              <li
-                key={i}
-                className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden"
-              >
-                <div className="px-4 py-3 border-b border-gray-100 bg-gray-50/80 flex items-center justify-between gap-2">
-                  <span className="text-sm font-semibold text-gray-900">
-                    Panel {i + 1}
-                    {panelCount ? (
-                      <span className="font-normal text-gray-500">
-                        {' '}
-                        of {panelCount}
-                      </span>
-                    ) : null}
-                  </span>
-                </div>
-                <div className="p-4 sm:p-6">
+        <div className="px-4 sm:px-8 py-8">
+          {panelCount === 0 ? (
+            <p className="text-sm text-gray-500 italic text-center py-12">
+              No panels were generated for this comic.
+            </p>
+          ) : (
+            <section
+              aria-label="Panel viewer"
+              aria-roledescription="carousel"
+              aria-live="polite"
+              className="space-y-4"
+            >
+              <div className="flex items-center justify-between">
+                <span className="inline-flex h-7 items-center px-3 rounded-full bg-gradient-to-r from-indigo-500 to-violet-500 text-xs font-bold uppercase tracking-wider text-white shadow">
+                  Panel {safeIndex + 1} of {panelCount}
+                </span>
+                <span className="text-xs text-gray-500 hidden sm:inline">Use ← → keys</span>
+              </div>
+
+              <div className="relative page-stage">
+                <div
+                  key={`${safeIndex}-${turnTick}`}
+                  className={
+                    direction === 'backward' ? 'page-turn-backward' : 'page-turn-forward'
+                  }
+                >
                   <img
-                    src={uploadsUrl(panel.imagePath)}
-                    alt={panel.caption || `Panel ${i + 1}`}
-                    className="w-full rounded-lg border border-gray-200"
+                    src={uploadsUrl(current.imagePath)}
+                    alt={current.caption || `Panel ${safeIndex + 1}`}
+                    className="w-full rounded-lg border border-gray-200 shadow-sm bg-gray-50"
                   />
-                  {panel.caption ? (
-                    <p className="mt-3 text-sm text-gray-600 leading-relaxed">{panel.caption}</p>
-                  ) : null}
-                  {panel.prompt ? (
-                    <details className="mt-3 group">
-                      <summary className="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700">
-                        Image prompt used
-                      </summary>
-                      <pre className="mt-2 text-xs text-gray-600 whitespace-pre-wrap break-words bg-gray-50 rounded-lg p-3 border border-gray-100">
-                        {panel.prompt}
-                      </pre>
-                    </details>
+
+                  {current.caption ? (
+                    <figcaption className="mt-5 mx-auto max-w-2xl rounded-lg border-l-4 border-indigo-400 bg-indigo-50/70 px-5 py-4 shadow-sm">
+                      <p className="font-serif text-base sm:text-lg leading-relaxed text-gray-900 italic">
+                        {current.caption}
+                      </p>
+                    </figcaption>
                   ) : null}
                 </div>
-              </li>
-            ))}
-          </ol>
-        </section>
-      </div>
+
+                <button
+                  type="button"
+                  onClick={goPrev}
+                  disabled={panelCount < 2}
+                  aria-label="Previous panel"
+                  className="absolute left-2 sm:-left-4 top-1/2 -translate-y-1/2 inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/95 border border-gray-200 shadow-md text-gray-800 hover:bg-white hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed z-10"
+                >
+                  <svg
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="h-5 w-5"
+                    aria-hidden
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M12.79 5.23a.75.75 0 010 1.06L9.06 10l3.73 3.71a.75.75 0 11-1.06 1.06l-4.25-4.24a.75.75 0 010-1.06l4.25-4.24a.75.75 0 011.06 0z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={goNext}
+                  disabled={panelCount < 2}
+                  aria-label="Next panel"
+                  className="absolute right-2 sm:-right-4 top-1/2 -translate-y-1/2 inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/95 border border-gray-200 shadow-md text-gray-800 hover:bg-white hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed z-10"
+                >
+                  <svg
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="h-5 w-5"
+                    aria-hidden
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M7.21 14.77a.75.75 0 010-1.06L10.94 10 7.21 6.29a.75.75 0 111.06-1.06l4.25 4.24a.75.75 0 010 1.06l-4.25 4.24a.75.75 0 01-1.06 0z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-center gap-2 pt-2">
+                {panels.map((_, i) => {
+                  const active = i === safeIndex;
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => turnTo(i, i >= safeIndex ? 'forward' : 'backward')}
+                      aria-label={`Go to panel ${i + 1}`}
+                      aria-current={active ? 'true' : undefined}
+                      className={[
+                        'h-2.5 rounded-full transition-all',
+                        active
+                          ? 'w-6 bg-gradient-to-r from-indigo-500 to-violet-500'
+                          : 'w-2.5 bg-gray-300 hover:bg-gray-400',
+                      ].join(' ')}
+                    />
+                  );
+                })}
+              </div>
+            </section>
+          )}
+        </div>
+
+        <footer className="px-6 sm:px-8 py-4 border-t border-gray-100 bg-gray-50/70 flex flex-wrap items-center justify-between gap-3">
+          <Link to="/comics" className="text-sm font-medium text-indigo-700 hover:text-indigo-900">
+            ← Back to library
+          </Link>
+          <Link
+            to="/comics/create"
+            className="text-sm font-medium text-gray-700 hover:text-gray-900"
+          >
+            Create another →
+          </Link>
+        </footer>
+      </article>
     </PageShell>
   );
 }

--- a/frontend/src/pages/ComicDetailPage.jsx
+++ b/frontend/src/pages/ComicDetailPage.jsx
@@ -1,6 +1,19 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { api, uploadsUrl } from '../services/api';
+import PageShell from '../components/PageShell';
+
+function formatDate(iso) {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+  } catch {
+    return null;
+  }
+}
 
 export default function ComicDetailPage() {
   const { id } = useParams();
@@ -21,69 +34,129 @@ export default function ComicDetailPage() {
       }
     }
     if (id) fetchComic();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   if (loading) {
     return (
-      <div className="px-4 py-6 sm:px-0">
-        <div className="flex justify-center py-12">
-          <p className="text-gray-500">Loading…</p>
+      <PageShell eyebrow="Comic" title="Loading…" description="Fetching panels and metadata.">
+        <div className="flex justify-center py-16 rounded-xl border border-gray-200 bg-white">
+          <p className="text-gray-500 text-sm">Loading…</p>
         </div>
-      </div>
+      </PageShell>
     );
   }
 
   if (error || !comic) {
     return (
-      <div className="px-4 py-6 sm:px-0">
-        <div className="rounded-lg bg-red-50 p-4 text-red-700 mb-4">
+      <PageShell eyebrow="Comic" title="Could not open comic">
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-800 text-sm mb-4">
           {error || 'Comic not found.'}
         </div>
-        <Link to="/comics" className="text-blue-600 hover:text-blue-700 font-medium">
+        <Link to="/comics" className="text-blue-600 hover:text-blue-700 font-medium text-sm">
           ← Back to comics
         </Link>
-      </div>
+      </PageShell>
     );
   }
 
+  const panelCount = comic.panels?.length ?? 0;
+  const created = formatDate(comic.createdAt);
+
   return (
-    <div className="px-4 py-6 sm:px-0">
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <h2 className="text-2xl font-bold text-gray-900">{comic.title}</h2>
-          <p className="text-gray-500 mt-1">
-            {comic.style} · {comic.panels?.length ?? 0} panels
-          </p>
-        </div>
+    <PageShell
+      eyebrow="Comic"
+      title={comic.title}
+      description="Summary and panels in order. Captions appear under each image when the model provided them."
+      actions={
         <Link
           to="/comics"
-          className="text-gray-600 hover:text-gray-900 font-medium"
+          className="text-sm font-medium text-gray-600 hover:text-gray-900"
         >
           ← Back to comics
         </Link>
-      </div>
-      {comic.description && (
-        <p className="text-gray-600 mb-8 max-w-2xl">{comic.description}</p>
-      )}
-      <div className="bg-white rounded-lg shadow overflow-hidden">
-        <div className="divide-y divide-gray-100">
-          {(comic.panels || []).map((panel, i) => (
-            <div key={i} className="p-4 sm:p-6">
-              <div className="max-w-2xl mx-auto">
-                <img
-                  src={uploadsUrl(panel.imagePath)}
-                  alt={panel.caption || `Panel ${i + 1}`}
-                  className="w-full rounded-lg border border-gray-200"
-                />
-                {panel.caption && (
-                  <p className="mt-2 text-sm text-gray-500 italic">{panel.caption}</p>
-                )}
-              </div>
+      }
+    >
+      <div className="space-y-8 max-w-3xl">
+        <section
+          aria-labelledby="meta-heading"
+          className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden"
+        >
+          <h2 id="meta-heading" className="sr-only">
+            Comic details
+          </h2>
+          <dl className="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-100">
+            <div className="px-5 py-4">
+              <dt className="text-xs font-semibold uppercase tracking-wider text-gray-500">Style</dt>
+              <dd className="mt-1 text-sm font-medium text-gray-900 capitalize">{comic.style}</dd>
             </div>
-          ))}
-        </div>
+            <div className="px-5 py-4">
+              <dt className="text-xs font-semibold uppercase tracking-wider text-gray-500">Panels</dt>
+              <dd className="mt-1 text-sm font-medium text-gray-900">{panelCount}</dd>
+            </div>
+            <div className="px-5 py-4">
+              <dt className="text-xs font-semibold uppercase tracking-wider text-gray-500">Created</dt>
+              <dd className="mt-1 text-sm font-medium text-gray-900">{created || '—'}</dd>
+            </div>
+          </dl>
+          {comic.description ? (
+            <div className="px-5 py-4 border-t border-gray-100">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+                Story summary
+              </h3>
+              <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">{comic.description}</p>
+            </div>
+          ) : null}
+        </section>
+
+        <section aria-labelledby="panels-heading">
+          <h2 id="panels-heading" className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">
+            Panels ({panelCount})
+          </h2>
+          <ol className="space-y-6 list-none p-0 m-0">
+            {(comic.panels || []).map((panel, i) => (
+              <li
+                key={i}
+                className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden"
+              >
+                <div className="px-4 py-3 border-b border-gray-100 bg-gray-50/80 flex items-center justify-between gap-2">
+                  <span className="text-sm font-semibold text-gray-900">
+                    Panel {i + 1}
+                    {panelCount ? (
+                      <span className="font-normal text-gray-500">
+                        {' '}
+                        of {panelCount}
+                      </span>
+                    ) : null}
+                  </span>
+                </div>
+                <div className="p-4 sm:p-6">
+                  <img
+                    src={uploadsUrl(panel.imagePath)}
+                    alt={panel.caption || `Panel ${i + 1}`}
+                    className="w-full rounded-lg border border-gray-200"
+                  />
+                  {panel.caption ? (
+                    <p className="mt-3 text-sm text-gray-600 leading-relaxed">{panel.caption}</p>
+                  ) : null}
+                  {panel.prompt ? (
+                    <details className="mt-3 group">
+                      <summary className="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700">
+                        Image prompt used
+                      </summary>
+                      <pre className="mt-2 text-xs text-gray-600 whitespace-pre-wrap break-words bg-gray-50 rounded-lg p-3 border border-gray-100">
+                        {panel.prompt}
+                      </pre>
+                    </details>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/frontend/src/pages/ComicsPage.jsx
+++ b/frontend/src/pages/ComicsPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api, uploadsUrl } from '../services/api';
+import PageShell from '../components/PageShell';
 
 export default function ComicsPage() {
   const [comics, setComics] = useState([]);
@@ -20,40 +21,52 @@ export default function ComicsPage() {
       }
     }
     fetchComics();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   if (loading) {
     return (
-      <div className="px-4 py-6 sm:px-0">
-        <h2 className="text-2xl font-bold text-gray-900 mb-6">Comics</h2>
-        <div className="flex justify-center py-12">
-          <p className="text-gray-500">Loading…</p>
+      <PageShell
+        eyebrow="Your work"
+        title="Comics"
+        description="All generated comics, newest first in this list."
+      >
+        <div className="flex justify-center py-16 rounded-xl border border-gray-200 bg-white">
+          <p className="text-gray-500 text-sm">Loading…</p>
         </div>
-      </div>
+      </PageShell>
     );
   }
 
   if (error) {
     return (
-      <div className="px-4 py-6 sm:px-0">
-        <h2 className="text-2xl font-bold text-gray-900 mb-6">Comics</h2>
-        <div className="rounded-lg bg-red-50 p-4 text-red-700">{error}</div>
-      </div>
+      <PageShell eyebrow="Your work" title="Comics" description="Browse everything you have generated.">
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-800 text-sm">{error}</div>
+      </PageShell>
     );
   }
 
   return (
-    <div className="px-4 py-6 sm:px-0">
-      <h2 className="text-2xl font-bold text-gray-900 mb-6">Comics</h2>
+    <PageShell
+      eyebrow="Your work"
+      title="Comics"
+      description="Each card opens the full comic with panels in reading order."
+      actions={
+        <Link
+          to="/comics/create"
+          className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+        >
+          New comic
+        </Link>
+      }
+    >
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {comics.length === 0 ? (
-          <div className="col-span-full text-center py-12">
-            <p className="text-gray-500 mb-4">No comics yet.</p>
-            <Link
-              to="/comics/create"
-              className="text-blue-600 hover:text-blue-700 font-medium"
-            >
+          <div className="col-span-full rounded-xl border border-gray-200 bg-white py-16 px-6 text-center shadow-sm">
+            <p className="text-gray-600 mb-4">No comics yet.</p>
+            <Link to="/comics/create" className="text-blue-600 hover:text-blue-700 font-medium text-sm">
               Create your first comic →
             </Link>
           </div>
@@ -62,7 +75,7 @@ export default function ComicsPage() {
             <Link
               key={c._id}
               to={`/comics/${c._id}`}
-              className="group block bg-white rounded-lg shadow overflow-hidden hover:shadow-md transition"
+              className="group block rounded-xl border border-gray-200 bg-white overflow-hidden shadow-sm hover:border-gray-300 hover:shadow-md transition"
             >
               <div className="aspect-[3/4] bg-gray-100 flex items-center justify-center">
                 {c.panels?.[0]?.imagePath ? (
@@ -72,21 +85,23 @@ export default function ComicsPage() {
                     className="w-full h-full object-cover"
                   />
                 ) : (
-                  <span className="text-4xl text-gray-400">📖</span>
+                  <span className="text-4xl text-gray-400" aria-hidden>
+                    📖
+                  </span>
                 )}
               </div>
-              <div className="p-4">
-                <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 truncate">
-                  {c.title}
-                </h3>
+              <div className="p-4 border-t border-gray-100">
+                <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 truncate">{c.title}</h3>
                 <p className="text-sm text-gray-500 mt-1">
-                  {c.style} · {c.panels?.length ?? 0} panels
+                  <span className="capitalize">{c.style}</span>
+                  <span className="mx-1.5 text-gray-300">·</span>
+                  <span>{c.panels?.length ?? 0} panels</span>
                 </p>
               </div>
             </Link>
           ))
         )}
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/frontend/src/pages/ComicsPage.jsx
+++ b/frontend/src/pages/ComicsPage.jsx
@@ -7,6 +7,7 @@ export default function ComicsPage() {
   const [comics, setComics] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [deletingId, setDeletingId] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -26,14 +27,29 @@ export default function ComicsPage() {
     };
   }, []);
 
+  async function handleDelete(comic) {
+    const ok = window.confirm(`Delete "${comic.title}"? This cannot be undone.`);
+    if (!ok) return;
+    setDeletingId(comic._id);
+    try {
+      await api.delete(`/comics/${comic._id}`);
+      setComics((prev) => prev.filter((c) => c._id !== comic._id));
+    } catch (err) {
+      const msg = err.response?.data?.message || err.message || 'Failed to delete comic.';
+      window.alert(msg);
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
   if (loading) {
     return (
       <PageShell
         eyebrow="Your work"
         title="Comics"
-        description="All generated comics, newest first in this list."
+        description="All generated comics, newest first."
       >
-        <div className="flex justify-center py-16 rounded-xl border border-gray-200 bg-white">
+        <div className="flex justify-center py-16 rounded-xl border border-white/70 bg-white/80 backdrop-blur shadow-sm">
           <p className="text-gray-500 text-sm">Loading…</p>
         </div>
       </PageShell>
@@ -52,11 +68,15 @@ export default function ComicsPage() {
     <PageShell
       eyebrow="Your work"
       title="Comics"
-      description="Each card opens the full comic with panels in reading order."
+      description={
+        comics.length
+          ? `You have ${comics.length} comic${comics.length === 1 ? '' : 's'}. Click a card to read; use Delete to remove from the database.`
+          : 'No comics yet. Generate your first one to start a library.'
+      }
       actions={
         <Link
           to="/comics/create"
-          className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+          className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-semibold text-white bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-700 hover:to-violet-700 shadow-sm"
         >
           New comic
         </Link>
@@ -64,42 +84,67 @@ export default function ComicsPage() {
     >
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {comics.length === 0 ? (
-          <div className="col-span-full rounded-xl border border-gray-200 bg-white py-16 px-6 text-center shadow-sm">
+          <div className="col-span-full rounded-xl border border-white/70 bg-white py-16 px-6 text-center shadow-sm">
             <p className="text-gray-600 mb-4">No comics yet.</p>
-            <Link to="/comics/create" className="text-blue-600 hover:text-blue-700 font-medium text-sm">
+            <Link
+              to="/comics/create"
+              className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-semibold text-white bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-700 hover:to-violet-700"
+            >
               Create your first comic →
             </Link>
           </div>
         ) : (
-          comics.map((c) => (
-            <Link
-              key={c._id}
-              to={`/comics/${c._id}`}
-              className="group block rounded-xl border border-gray-200 bg-white overflow-hidden shadow-sm hover:border-gray-300 hover:shadow-md transition"
-            >
-              <div className="aspect-[3/4] bg-gray-100 flex items-center justify-center">
-                {c.panels?.[0]?.imagePath ? (
-                  <img
-                    src={uploadsUrl(c.panels[0].imagePath)}
-                    alt=""
-                    className="w-full h-full object-cover"
-                  />
-                ) : (
-                  <span className="text-4xl text-gray-400" aria-hidden>
-                    📖
-                  </span>
-                )}
+          comics.map((c) => {
+            const isDeleting = deletingId === c._id;
+            return (
+              <div
+                key={c._id}
+                className="group relative overflow-hidden rounded-xl border border-white/70 bg-white shadow-sm hover:shadow-md transition"
+              >
+                <Link to={`/comics/${c._id}`} className="block">
+                  <div className="aspect-[3/4] bg-gradient-to-br from-indigo-100 via-violet-100 to-rose-100 flex items-center justify-center">
+                    {c.panels?.[0]?.imagePath ? (
+                      <img
+                        src={uploadsUrl(c.panels[0].imagePath)}
+                        alt=""
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-4xl text-indigo-400" aria-hidden>
+                        📖
+                      </span>
+                    )}
+                  </div>
+                  <div className="p-4 border-t border-gray-100">
+                    <h3 className="font-semibold text-gray-900 group-hover:text-indigo-700 truncate">
+                      {c.title}
+                    </h3>
+                    <p className="text-sm text-gray-500 mt-1">
+                      <span className="capitalize">{c.style}</span>
+                      <span className="mx-1.5 text-gray-300">·</span>
+                      <span>{c.panels?.length ?? 0} panels</span>
+                    </p>
+                  </div>
+                </Link>
+                <div className="flex items-center justify-between gap-2 px-4 pb-4">
+                  <Link
+                    to={`/comics/${c._id}`}
+                    className="text-xs font-medium text-indigo-700 hover:text-indigo-900"
+                  >
+                    Read →
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(c)}
+                    disabled={isDeleting}
+                    className="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium text-rose-700 bg-rose-50 border border-rose-200 hover:bg-rose-100 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isDeleting ? 'Deleting…' : 'Delete'}
+                  </button>
+                </div>
               </div>
-              <div className="p-4 border-t border-gray-100">
-                <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 truncate">{c.title}</h3>
-                <p className="text-sm text-gray-500 mt-1">
-                  <span className="capitalize">{c.style}</span>
-                  <span className="mx-1.5 text-gray-300">·</span>
-                  <span>{c.panels?.length ?? 0} panels</span>
-                </p>
-              </div>
-            </Link>
-          ))
+            );
+          })
         )}
       </div>
     </PageShell>

--- a/frontend/src/pages/CreateComicPage.jsx
+++ b/frontend/src/pages/CreateComicPage.jsx
@@ -73,7 +73,7 @@ export default function CreateComicPage() {
                 id="title"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="e.g. The Last Samurai"
                 disabled={loading}
               />
@@ -87,7 +87,7 @@ export default function CreateComicPage() {
                 rows={6}
                 value={story}
                 onChange={(e) => setStory(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="Write your story or scene descriptions. The AI will turn them into comic panels."
                 disabled={loading}
               />
@@ -109,7 +109,7 @@ export default function CreateComicPage() {
                 id="style"
                 value={style}
                 onChange={(e) => setStyle(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                 disabled={loading}
               >
                 {STYLES.map((s) => (
@@ -127,7 +127,7 @@ export default function CreateComicPage() {
                 id="panels"
                 value={numPanels}
                 onChange={(e) => setNumPanels(Number(e.target.value))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                 disabled={loading}
               >
                 {PANEL_OPTS.map((n) => (
@@ -156,7 +156,7 @@ export default function CreateComicPage() {
           <button
             type="submit"
             disabled={loading}
-            className="px-4 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-5 py-2 border border-transparent text-sm font-semibold rounded-lg shadow-sm text-white bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-700 hover:to-violet-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? 'Generating…' : 'Generate comic'}
           </button>

--- a/frontend/src/pages/CreateComicPage.jsx
+++ b/frontend/src/pages/CreateComicPage.jsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
+import PageShell from '../components/PageShell';
+import SectionBlock from '../components/SectionBlock';
 
 const STYLES = [
   { value: 'shounen', label: 'Shounen', desc: 'Action, adventure, bold' },
@@ -50,42 +52,55 @@ export default function CreateComicPage() {
   }
 
   return (
-    <div className="px-4 py-6 sm:px-0">
-      <h2 className="text-2xl font-bold text-gray-900 mb-2">Create Comic with AI</h2>
-      <p className="text-gray-500 mb-6">
-        Describe your story. AI will split it into panels and generate manga-style art.
-      </p>
-      <div className="bg-white shadow rounded-lg p-6 max-w-2xl">
-        <form onSubmit={handleSubmit}>
-          <div className="mb-4">
-            <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
-              Title
-            </label>
-            <input
-              type="text"
-              id="title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              placeholder="e.g. The Last Samurai"
-              disabled={loading}
-            />
+    <PageShell
+      eyebrow="Generator"
+      title="Create a comic"
+      description="Fill in the sections below in order. The server splits your story into panels and requests an image per panel—generation can take a minute."
+    >
+      <form onSubmit={handleSubmit} className="space-y-6 max-w-2xl">
+        <SectionBlock
+          id="section-story"
+          title="1. Comic text"
+          description="What readers will see as the premise; the model also uses this to decide what goes in each panel."
+        >
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
+                Title
+              </label>
+              <input
+                type="text"
+                id="title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="e.g. The Last Samurai"
+                disabled={loading}
+              />
+            </div>
+            <div>
+              <label htmlFor="story" className="block text-sm font-medium text-gray-700 mb-2">
+                Story
+              </label>
+              <textarea
+                id="story"
+                rows={6}
+                value={story}
+                onChange={(e) => setStory(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="Write your story or scene descriptions. The AI will turn them into comic panels."
+                disabled={loading}
+              />
+            </div>
           </div>
-          <div className="mb-4">
-            <label htmlFor="story" className="block text-sm font-medium text-gray-700 mb-2">
-              Story
-            </label>
-            <textarea
-              id="story"
-              rows={6}
-              value={story}
-              onChange={(e) => setStory(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Write your story or scene descriptions. The AI will turn them into comic panels."
-              disabled={loading}
-            />
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+        </SectionBlock>
+
+        <SectionBlock
+          id="section-look"
+          title="2. Look & length"
+          description="Style presets map to the image prompt; panel count is how many images are generated."
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label htmlFor="style" className="block text-sm font-medium text-gray-700 mb-2">
                 Style
@@ -94,7 +109,7 @@ export default function CreateComicPage() {
                 id="style"
                 value={style}
                 onChange={(e) => setStyle(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 disabled={loading}
               >
                 {STYLES.map((s) => (
@@ -112,7 +127,7 @@ export default function CreateComicPage() {
                 id="panels"
                 value={numPanels}
                 onChange={(e) => setNumPanels(Number(e.target.value))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 disabled={loading}
               >
                 {PANEL_OPTS.map((n) => (
@@ -123,28 +138,30 @@ export default function CreateComicPage() {
               </select>
             </div>
           </div>
-          {error && (
-            <div className="mb-4 p-3 rounded-md bg-red-50 text-red-700 text-sm">{error}</div>
-          )}
-          <div className="flex justify-end gap-3">
-            <button
-              type="button"
-              onClick={() => navigate(-1)}
-              className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-              disabled={loading}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={loading}
-              className="px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {loading ? 'Generating…' : 'Generate comic'}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+        </SectionBlock>
+
+        {error ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-red-800 text-sm">{error}</div>
+        ) : null}
+
+        <div className="flex flex-wrap justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 disabled:opacity-50 text-sm font-medium"
+            disabled={loading}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="px-4 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Generating…' : 'Generate comic'}
+          </button>
+        </div>
+      </form>
+    </PageShell>
   );
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,75 +1,101 @@
 import { Link } from 'react-router-dom';
-import PageShell from '../components/PageShell';
 
 const STEPS = [
-  { n: 1, title: 'Write your story', body: 'Add a title and a short scene or plot in plain language.' },
-  { n: 2, title: 'Pick style & panels', body: 'Choose a manga-style preset and how many panels to generate.' },
-  { n: 3, title: 'Review the comic', body: 'Open your comic to read captions and see each panel in order.' },
+  {
+    n: 1,
+    title: 'Write your story',
+    body: 'Add a title and a short scene or plot in plain language.',
+    accent: 'from-indigo-500 to-blue-500',
+  },
+  {
+    n: 2,
+    title: 'Pick style & panels',
+    body: 'Choose a manga-style preset and how many panels to generate.',
+    accent: 'from-violet-500 to-fuchsia-500',
+  },
+  {
+    n: 3,
+    title: 'Review the comic',
+    body: 'Open your comic to read captions and step through panels.',
+    accent: 'from-rose-500 to-orange-500',
+  },
 ];
 
 const HomePage = () => {
   return (
-    <PageShell
-      eyebrow="Comic Generator"
-      title="Turn a written story into a panel comic"
-      description="The app splits your text into panels and generates images for each one. Quality depends on the configured image model—use the Create flow to see exactly what you get today."
-      actions={
-        <>
-          <Link
-            to="/comics/create"
-            className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-          >
-            Create a comic
-          </Link>
-          <Link
-            to="/comics"
-            className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-          >
-            View comics
-          </Link>
-        </>
-      }
-    >
-      <div className="space-y-10">
-        <section aria-labelledby="how-heading">
-          <h2 id="how-heading" className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">
-            How it works
-          </h2>
-          <ol className="grid gap-4 sm:grid-cols-3">
-            {STEPS.map((s) => (
-              <li
-                key={s.n}
-                className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm flex gap-4"
-              >
-                <span
-                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-800"
-                  aria-hidden
-                >
-                  {s.n}
-                </span>
-                <div>
-                  <h3 className="font-semibold text-gray-900">{s.title}</h3>
-                  <p className="mt-1 text-sm text-gray-600 leading-relaxed">{s.body}</p>
-                </div>
-              </li>
-            ))}
-          </ol>
-        </section>
-
-        <section className="rounded-xl border border-dashed border-gray-300 bg-gray-50/80 p-6">
-          <h2 className="text-sm font-semibold text-gray-900">Product overview</h2>
-          <p className="mt-2 text-sm text-gray-600 leading-relaxed max-w-2xl">
-            For a full feature walkthrough and positioning, open the{' '}
-            <Link to="/manga-ai" className="text-blue-600 font-medium hover:text-blue-700">
-              Manga AI
-            </Link>{' '}
-            page. The editor and your saved comics always live under{' '}
-            <span className="font-medium text-gray-800">Create</span> and{' '}
-            <span className="font-medium text-gray-800">Comics</span> in the navigation bar.
+    <div className="px-4 py-6 sm:px-0 space-y-10">
+      <section
+        aria-label="Hero"
+        className="relative overflow-hidden rounded-2xl border border-white/70 bg-gradient-to-br from-indigo-600 via-violet-600 to-rose-500 p-8 sm:p-12 text-white shadow-lg"
+      >
+        <div
+          aria-hidden
+          className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-white/10 blur-3xl"
+        />
+        <div
+          aria-hidden
+          className="absolute -left-16 -bottom-16 h-56 w-56 rounded-full bg-rose-300/20 blur-3xl"
+        />
+        <div className="relative max-w-2xl">
+          <p className="text-xs font-semibold uppercase tracking-wider text-white/80 mb-3">
+            Stories → manga panels
           </p>
-        </section>
-      </div>
-    </PageShell>
+          <h1 className="text-3xl sm:text-4xl font-bold leading-tight">
+            Build a short comic in three steps
+          </h1>
+          <p className="mt-4 text-white/90 leading-relaxed">
+            No drawing required. Each generation gives you a sequence of panels you can read top to
+            bottom and keep in your library.
+          </p>
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Link
+              to="/comics/create"
+              className="inline-flex items-center px-5 py-2.5 rounded-lg text-sm font-semibold text-indigo-700 bg-white hover:bg-indigo-50 shadow-sm"
+            >
+              Start creating →
+            </Link>
+            <Link
+              to="/guide"
+              className="inline-flex items-center px-5 py-2.5 rounded-lg text-sm font-medium text-white border border-white/40 hover:bg-white/10"
+            >
+              Read the guide
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="how-heading">
+        <h2
+          id="how-heading"
+          className="text-sm font-semibold uppercase tracking-wider text-indigo-700 mb-4"
+        >
+          How it works
+        </h2>
+        <ol className="grid gap-4 sm:grid-cols-3">
+          {STEPS.map((s) => (
+            <li
+              key={s.n}
+              className="relative overflow-hidden rounded-xl border border-white/70 bg-white p-5 shadow-sm flex gap-4"
+            >
+              <span
+                aria-hidden
+                className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${s.accent}`}
+              />
+              <span
+                className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br ${s.accent} text-sm font-bold text-white shadow`}
+                aria-hidden
+              >
+                {s.n}
+              </span>
+              <div>
+                <h3 className="font-semibold text-gray-900">{s.title}</h3>
+                <p className="mt-1 text-sm text-gray-600 leading-relaxed">{s.body}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+    </div>
   );
 };
 

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,29 +1,75 @@
+import { Link } from 'react-router-dom';
+import PageShell from '../components/PageShell';
+
+const STEPS = [
+  { n: 1, title: 'Write your story', body: 'Add a title and a short scene or plot in plain language.' },
+  { n: 2, title: 'Pick style & panels', body: 'Choose a manga-style preset and how many panels to generate.' },
+  { n: 3, title: 'Review the comic', body: 'Open your comic to read captions and see each panel in order.' },
+];
+
 const HomePage = () => {
   return (
-    <div className="px-4 py-6 sm:px-0">
-      <div className="text-center">
-        <h2 className="text-4xl font-bold text-gray-900 mb-4">
-          Welcome to Comic Generator
-        </h2>
-        <p className="text-xl text-gray-600 mb-8">
-          Create amazing comics with ease
-        </p>
-        <div className="flex justify-center gap-4">
-          <a
-            href="/comics/create"
-            className="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+    <PageShell
+      eyebrow="Comic Generator"
+      title="Turn a written story into a panel comic"
+      description="The app splits your text into panels and generates images for each one. Quality depends on the configured image model—use the Create flow to see exactly what you get today."
+      actions={
+        <>
+          <Link
+            to="/comics/create"
+            className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
           >
-            Get Started
-          </a>
-          <a
-            href="/comics"
-            className="inline-flex items-center px-6 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            Create a comic
+          </Link>
+          <Link
+            to="/comics"
+            className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
           >
-            View Comics
-          </a>
-        </div>
+            View comics
+          </Link>
+        </>
+      }
+    >
+      <div className="space-y-10">
+        <section aria-labelledby="how-heading">
+          <h2 id="how-heading" className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">
+            How it works
+          </h2>
+          <ol className="grid gap-4 sm:grid-cols-3">
+            {STEPS.map((s) => (
+              <li
+                key={s.n}
+                className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm flex gap-4"
+              >
+                <span
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-800"
+                  aria-hidden
+                >
+                  {s.n}
+                </span>
+                <div>
+                  <h3 className="font-semibold text-gray-900">{s.title}</h3>
+                  <p className="mt-1 text-sm text-gray-600 leading-relaxed">{s.body}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="rounded-xl border border-dashed border-gray-300 bg-gray-50/80 p-6">
+          <h2 className="text-sm font-semibold text-gray-900">Product overview</h2>
+          <p className="mt-2 text-sm text-gray-600 leading-relaxed max-w-2xl">
+            For a full feature walkthrough and positioning, open the{' '}
+            <Link to="/manga-ai" className="text-blue-600 font-medium hover:text-blue-700">
+              Manga AI
+            </Link>{' '}
+            page. The editor and your saved comics always live under{' '}
+            <span className="font-medium text-gray-800">Create</span> and{' '}
+            <span className="font-medium text-gray-800">Comics</span> in the navigation bar.
+          </p>
+        </section>
       </div>
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/MangaAIPage.jsx
+++ b/frontend/src/pages/MangaAIPage.jsx
@@ -1,59 +1,37 @@
 import { Link } from 'react-router-dom';
-
-const NAV_LINKS = [
-  { label: 'Start creating', href: '#create' },
-  { label: 'Examples', href: '#gallery' },
-];
+import PageShell from '../components/PageShell';
 
 const PAGE_OUTLINE = [
-  { label: 'Ways to use the app', href: '#create' },
-  { label: 'Example ideas', href: '#gallery' },
+  { label: 'What you can do', href: '#create' },
   { label: 'Styles', href: '#styles' },
   { label: 'Who it is for', href: '#audience' },
   { label: 'Highlights', href: '#features' },
   { label: 'Steps', href: '#steps' },
 ];
 
-const BADGES = [
-  'Free Trial',
-  '14 Manga Genres',
-  'HD Export',
-];
-
-const GENRE_CHIPS = [
-  { emoji: '⚔️', label: 'Shounen' },
-  { emoji: '🌸', label: 'Shoujo' },
-  { emoji: '🎭', label: 'Seinen' },
-  { emoji: '✨', label: 'Isekai' },
-  { emoji: '🍥', label: 'Chibi' },
-];
-
 const CREATION_METHODS = [
   {
     title: 'Describe your story',
     description:
-      'This project generates comics from text: you add a title and a story, pick a style preset and panel count, and the backend splits the text and requests one image per panel.',
-    bullets: ['Works in the Create page today', 'Captions and prompts stored per panel', 'Results depend on the configured image model'],
-    cta: 'Open Create',
-    to: '/comics/create',
+      'Add a title and story on the Create page, pick a style preset and panel count. The server splits your text and requests one image per panel via Hugging Face.',
+    bullets: [
+      'Lives in the Create page in this app',
+      'Captions and prompts are stored per panel',
+      'Needs a valid API token and inference access (see backend README)',
+    ],
+    accent: 'from-indigo-500 to-violet-500',
   },
   {
     title: 'Browse finished comics',
     description:
-      'Every generated comic is listed under Comics with its cover thumbnail, style, and panel count. Open one to read panels in order and inspect captions.',
-    bullets: ['Grid of all your comics', 'Reading order is top to bottom', 'Optional prompt details per panel'],
-    cta: 'Open Comics',
-    to: '/comics',
+      'Every comic appears in your library with a thumbnail, style, and panel count. Open one to read top-to-bottom or delete it from the database.',
+    bullets: [
+      'Same navigation bar as the rest of the site',
+      'Optional prompt text per panel',
+      'Delete button removes the comic from the database',
+    ],
+    accent: 'from-rose-500 to-orange-500',
   },
-];
-
-const EXAMPLE_MANGA = [
-  { title: 'Demon Blade Chronicles', genre: 'Shounen Battle', style: 'Shounen', panels: 7 },
-  { title: 'Sakura First Love', genre: 'School Romance', style: 'Shoujo', panels: 4 },
-  { title: 'Tokyo Noir', genre: 'Mystery Thriller', style: 'Seinen', panels: 7 },
-  { title: 'Reborn as a Slime', genre: 'Isekai Fantasy', style: 'Isekai', panels: 6 },
-  { title: 'Café Memories', genre: 'Slice of Life', style: 'Josei', panels: 4 },
-  { title: 'Mecha Genesis', genre: 'Sci-Fi Action', style: 'Mecha', panels: 6 },
 ];
 
 const STYLES = [
@@ -72,351 +50,175 @@ const STYLES = [
 ];
 
 const USE_CASES = [
-  { title: 'Aspiring Mangaka', desc: 'Bring your manga dreams to life without years of art training.' },
-  { title: 'Light Novel Authors', desc: 'Visualize your light novel scenes and create manga adaptations.' },
-  { title: 'Anime Fans', desc: 'Create original manga stories inspired by your favorite genres and styles.' },
-  { title: 'Content Creators', desc: 'Make manga-style content for social media and YouTube.' },
+  { title: 'Aspiring storytellers', desc: 'Prototype a short comic from prose without drawing each frame by hand.' },
+  { title: 'Writers', desc: 'Visualize a scene or chapter as sequential panels.' },
+  { title: 'Fans of manga aesthetics', desc: 'Experiment with shounen, shoujo, and other style prompts.' },
+  { title: 'Builders', desc: 'Fork the repo and swap in a stronger image or chat model.' },
 ];
 
 const FEATURES = [
-  { title: 'Authentic Manga AI', desc: 'AI trained on manga art to create authentic Japanese-style illustrations.' },
-  { title: 'Character Consistency', desc: 'Characters maintain their unique design across all panels and pages.' },
-  { title: 'Panel Layouts', desc: 'Traditional manga panel layouts and compositions.' },
-  { title: 'Speed Lines & Effects', desc: 'Automatic manga effects like speed lines, screen tones, and SFX.' },
+  { title: 'Panel split + images', desc: 'One story becomes N panel descriptions, then N generated images.' },
+  { title: 'Style keywords', desc: 'Presets add manga-style direction to every image prompt.' },
+  { title: 'Library view', desc: 'Grid of comics with quick metadata, a detail reader, and delete.' },
+  { title: 'Open stack', desc: 'React UI, Express API, MongoDB, Hugging Face Inference.' },
 ];
 
 const STEPS = [
-  { n: 1, title: 'Choose Input', desc: 'Upload character designs or describe your story in text.' },
-  { n: 2, title: 'Select Manga Style', desc: 'Pick from shounen, shoujo, seinen, and more authentic styles.' },
-  { n: 3, title: 'Customize Panels', desc: 'Choose panel layouts and manga-specific effects.' },
-  { n: 4, title: 'Download & Share', desc: 'Get high-resolution manga pages ready for publishing.' },
-];
-
-const STATS = [
-  { value: 'Worldwide', label: 'Manga Created' },
-  { value: '12 Styles', label: 'Available' },
-  { value: '60-90 sec', label: 'Generation Time' },
+  { n: 1, title: 'Write', desc: 'Title and story on the Create page.' },
+  { n: 2, title: 'Configure', desc: 'Style preset and number of panels (2–8).' },
+  { n: 3, title: 'Generate', desc: 'Server calls Hugging Face; can take a minute.' },
+  { n: 4, title: 'Read', desc: 'Open the comic from your library to see panels in order.' },
 ];
 
 export default function MangaAIPage() {
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100 font-zen">
-      {/* Nav */}
-      <nav className="sticky top-0 z-50 border-b border-slate-800 bg-slate-950/90 backdrop-blur">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link to="/manga-ai" className="text-xl font-bold tracking-tight">
-              Manga AI
-            </Link>
-            <div className="flex items-center gap-4">
-              {NAV_LINKS.map(({ label, href }) => (
-                <a
-                  key={label}
-                  href={href}
-                  className="text-sm text-slate-400 hover:text-white transition"
-                >
-                  {label}
-                </a>
-              ))}
-              <a
-                href="#create"
-                className="rounded-full bg-rose-500 px-4 py-2 text-sm font-medium text-white hover:bg-rose-600 transition"
-              >
-                Try Free — No Payment Required
-              </a>
-            </div>
-          </div>
-        </div>
-      </nav>
-
-      {/* Page outline — quick jumps */}
-      <div className="border-b border-slate-800 bg-slate-900/80 backdrop-blur">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-2">On this page</p>
-          <nav aria-label="Page sections" className="flex flex-wrap gap-x-4 gap-y-2">
+    <PageShell
+      eyebrow="Guide"
+      title="Comic generator overview"
+      description="Longer-form context for what this app does and how it fits together. Everything here uses the same header and routes as Home, Create, and Comics."
+      actions={
+        <>
+          <Link
+            to="/comics/create"
+            className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-semibold text-white bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-700 hover:to-violet-700 shadow-sm"
+          >
+            Create a comic
+          </Link>
+          <Link
+            to="/comics"
+            className="inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50"
+          >
+            View comics
+          </Link>
+        </>
+      }
+    >
+      <div className="space-y-12 max-w-4xl">
+        <nav
+          aria-label="On this page"
+          className="rounded-xl border border-white/70 bg-white/80 p-4 shadow-sm backdrop-blur"
+        >
+          <p className="text-xs font-semibold uppercase tracking-wider text-indigo-700 mb-3">
+            On this page
+          </p>
+          <div className="flex flex-wrap gap-x-4 gap-y-2">
             {PAGE_OUTLINE.map((item) => (
               <a
                 key={item.href}
                 href={item.href}
-                className="text-sm text-slate-400 hover:text-rose-300 transition border-b border-transparent hover:border-rose-400/60 pb-0.5"
+                className="text-sm text-indigo-700 hover:text-indigo-900 border-b border-transparent hover:border-indigo-300 pb-0.5"
               >
                 {item.label}
               </a>
             ))}
-          </nav>
-        </div>
-      </div>
+          </div>
+        </nav>
 
-      {/* Hero */}
-      <section className="relative overflow-hidden pt-16 pb-24 sm:pt-24 sm:pb-32">
-        <div className="absolute inset-0 bg-gradient-to-b from-rose-950/20 via-transparent to-transparent" />
-        <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <p className="text-rose-400/90 text-sm font-medium uppercase tracking-wider mb-4">
-            Your Story, Illustrated in Manga Style
-          </p>
-          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight max-w-4xl mx-auto leading-tight">
-            Turn Your Ideas Into Authentic Manga — Zero Art Skills Required
-          </h1>
-          <p className="mt-6 text-lg sm:text-xl text-slate-400 max-w-2xl mx-auto">
-            Transform stories into manga pages instantly. Upload character references or describe scenes
-            in text, pick from shounen, shoujo, seinen aesthetics, and let AI craft your vision with
-            authentic Japanese style.
-          </p>
-          <div className="mt-10 flex flex-wrap justify-center gap-4">
-            <a
-              href="#create"
-              className="rounded-full bg-rose-500 px-6 py-3 text-base font-semibold text-white hover:bg-rose-600 transition"
-            >
-              Start Creating
-            </a>
-            <a
-              href="#gallery"
-              className="rounded-full border border-slate-600 px-6 py-3 text-base font-medium text-slate-300 hover:border-slate-500 hover:text-white transition"
-            >
-              View Examples
-            </a>
+        <section className="relative overflow-hidden rounded-2xl border border-white/70 bg-gradient-to-br from-indigo-600 via-violet-600 to-rose-500 p-8 sm:p-10 text-center text-white shadow-lg scroll-mt-28">
+          <div aria-hidden className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-white/10 blur-3xl" />
+          <div aria-hidden className="absolute -left-16 -bottom-16 h-56 w-56 rounded-full bg-rose-300/20 blur-3xl" />
+          <div className="relative">
+            <p className="text-xs font-semibold uppercase tracking-wider text-white/80 mb-3">
+              Manga-style panels from text
+            </p>
+            <h2 className="text-2xl sm:text-3xl font-bold tracking-tight max-w-2xl mx-auto leading-snug">
+              Turn a written story into a short comic inside this single app
+            </h2>
+            <p className="mt-4 text-white/90 max-w-xl mx-auto leading-relaxed">
+              The same top navigation everywhere: Home, Comics, Create, and this guide. No separate
+              marketing site—only different pages.
+            </p>
           </div>
-          <div className="mt-12 flex flex-wrap justify-center gap-6 text-slate-500 text-sm">
-            {BADGES.map((b) => (
-              <span key={b} className="flex items-center gap-2">
-                <span className="h-1.5 w-1.5 rounded-full bg-rose-500" />
-                {b}
-              </span>
-            ))}
-          </div>
-          <div className="mt-10 flex flex-wrap justify-center gap-2">
-            {GENRE_CHIPS.map(({ emoji, label }) => (
-              <span
-                key={label}
-                className="rounded-full border border-slate-700 bg-slate-900/50 px-4 py-2 text-sm text-slate-300"
-              >
-                {emoji} {label}
-              </span>
-            ))}
-          </div>
-        </div>
-      </section>
+        </section>
 
-      {/* Two Ways to Create */}
-      <section id="create" className="py-20 border-t border-slate-800 scroll-mt-24">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-center mb-4">What you can do in this app</h2>
-          <p className="text-slate-400 text-center max-w-2xl mx-auto mb-16">
-            The live product is the Create and Comics flows linked below—this page is an overview of the idea and positioning.
+        <section id="create" className="scroll-mt-28 space-y-6">
+          <h2 className="text-xl font-bold text-gray-900">What you can do in this app</h2>
+          <p className="text-gray-600 leading-relaxed">
+            The running product is the Create and Comics flows—this page only explains them in more
+            detail. Use the buttons in the page header above to jump in.
           </p>
-          <div className="grid md:grid-cols-2 gap-8">
+          <div className="grid md:grid-cols-2 gap-6">
             {CREATION_METHODS.map((m) => (
               <div
                 key={m.title}
-                className="rounded-2xl border border-slate-800 bg-slate-900/50 p-8 hover:border-slate-700 transition"
+                className="relative overflow-hidden rounded-xl border border-white/70 bg-white p-6 shadow-sm hover:shadow-md transition"
               >
-                <h3 className="text-xl font-bold mb-4">{m.title}</h3>
-                <p className="text-slate-400 mb-6 leading-relaxed">{m.description}</p>
-                <ul className="space-y-2 mb-8">
+                <span aria-hidden className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${m.accent}`} />
+                <h3 className="text-lg font-semibold text-gray-900 mb-3">{m.title}</h3>
+                <p className="text-gray-600 text-sm leading-relaxed mb-4">{m.description}</p>
+                <ul className="space-y-2">
                   {m.bullets.map((b) => (
-                    <li key={b} className="flex items-start gap-2 text-slate-300 text-sm leading-relaxed">
-                      <span className="text-rose-500 shrink-0 mt-0.5">•</span>
+                    <li key={b} className="flex items-start gap-2 text-sm text-gray-700 leading-relaxed">
+                      <span className="text-indigo-600 shrink-0 mt-0.5">•</span>
                       <span>{b}</span>
                     </li>
                   ))}
                 </ul>
-                <Link
-                  to={m.to}
-                  className="inline-block rounded-full bg-rose-500 px-5 py-2.5 text-sm font-medium text-white hover:bg-rose-600 transition"
-                >
-                  {m.cta}
-                </Link>
               </div>
             ))}
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* Gallery */}
-      <section id="gallery" className="py-20 border-t border-slate-800 bg-slate-900/30 scroll-mt-24">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-center mb-4">Manga Created with Manga AI</h2>
-          <p className="text-slate-400 text-center mb-12">
-            From action-packed shounen to heartfelt shoujo — see what&apos;s possible
+        <section id="styles" className="scroll-mt-28 space-y-6 pt-4 border-t border-white/60">
+          <h2 className="text-xl font-bold text-gray-900">Style presets</h2>
+          <p className="text-gray-600 text-sm">
+            The Create page exposes a subset; extras below are examples of how prompts could be
+            extended in code.
           </p>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {EXAMPLE_MANGA.map((m) => (
-              <div
-                key={m.title}
-                className="group rounded-2xl border border-slate-800 bg-slate-900/50 overflow-hidden hover:border-slate-600 transition"
-              >
-                <div className="aspect-[3/4] bg-gradient-to-br from-slate-800 to-slate-900 flex items-center justify-center">
-                  <span className="text-6xl opacity-50 group-hover:opacity-70 transition">📖</span>
-                </div>
-                <div className="p-4">
-                  <h3 className="font-bold text-lg">{m.title}</h3>
-                  <p className="text-slate-500 text-sm">{m.genre}</p>
-                  <div className="mt-2 flex gap-2 text-xs text-slate-400">
-                    <span>{m.style}</span>
-                    <span>•</span>
-                    <span>{m.panels} panels</span>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="mt-10 text-center">
-            <a
-              href="#gallery"
-              className="text-rose-400 hover:text-rose-300 font-medium"
-            >
-              View Full Manga Gallery →
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/* Choose Your Manga Style */}
-      <section id="styles" className="py-20 border-t border-slate-800 scroll-mt-24">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-center mb-4">Choose Your Manga Style</h2>
-          <p className="text-slate-400 text-center mb-12">
-            Authentic manga art styles for every type of story
-          </p>
-          <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-4">
+          <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
             {STYLES.map((s) => (
-              <a
+              <div
                 key={s.label}
-                href="#create"
-                className="flex flex-col items-center rounded-xl border border-slate-800 bg-slate-900/50 p-6 hover:border-rose-500/50 hover:bg-slate-800/50 transition"
+                className="flex flex-col items-center rounded-xl border border-white/70 bg-white p-4 shadow-sm"
               >
-                <span className="text-3xl mb-2">{s.emoji}</span>
-                <span className="text-sm font-medium text-slate-300">{s.label}</span>
-              </a>
+                <span className="text-2xl mb-1" aria-hidden>
+                  {s.emoji}
+                </span>
+                <span className="text-xs font-medium text-gray-800">{s.label}</span>
+              </div>
             ))}
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* Perfect For */}
-      <section id="audience" className="py-20 border-t border-slate-800 bg-slate-900/30 scroll-mt-24">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-center mb-4">Perfect For Every Manga Creator</h2>
-          <p className="text-slate-400 text-center mb-12">
-            From aspiring mangaka to seasoned artists — Manga AI empowers everyone
-          </p>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        <section id="audience" className="scroll-mt-28 space-y-6 pt-4 border-t border-white/60">
+          <h2 className="text-xl font-bold text-gray-900">Who it is for</h2>
+          <div className="grid sm:grid-cols-2 gap-4">
             {USE_CASES.map((u) => (
-              <div
-                key={u.title}
-                className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6"
-              >
-                <h3 className="font-bold text-lg mb-2">{u.title}</h3>
-                <p className="text-slate-400 text-sm">{u.desc}</p>
+              <div key={u.title} className="rounded-xl border border-white/70 bg-white p-5 shadow-sm">
+                <h3 className="font-semibold text-gray-900 mb-2">{u.title}</h3>
+                <p className="text-gray-600 text-sm leading-relaxed">{u.desc}</p>
               </div>
             ))}
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* Why Choose */}
-      <section id="features" className="py-20 border-t border-slate-800 scroll-mt-24">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-center mb-4">Why Choose Manga AI?</h2>
-          <p className="text-slate-400 text-center mb-12">
-            Professional manga creation made simple
-          </p>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        <section id="features" className="scroll-mt-28 space-y-6 pt-4 border-t border-white/60">
+          <h2 className="text-xl font-bold text-gray-900">What the stack does</h2>
+          <div className="grid sm:grid-cols-2 gap-4">
             {FEATURES.map((f) => (
-              <div
-                key={f.title}
-                className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6"
-              >
-                <h3 className="font-bold text-lg mb-2">{f.title}</h3>
-                <p className="text-slate-400 text-sm">{f.desc}</p>
+              <div key={f.title} className="rounded-xl border border-white/70 bg-white p-5 shadow-sm">
+                <h3 className="font-semibold text-gray-900 mb-2">{f.title}</h3>
+                <p className="text-gray-600 text-sm leading-relaxed">{f.desc}</p>
               </div>
             ))}
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* 4 Steps */}
-      <section id="steps" className="py-20 border-t border-slate-800 bg-slate-900/30 scroll-mt-24">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-center mb-4">Create Your Manga in 4 Simple Steps</h2>
-          <p className="text-slate-400 text-center mb-12">
-            Begin with complimentary credits — no payment info needed
-          </p>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-8">
+        <section id="steps" className="scroll-mt-28 space-y-6 pt-4 border-t border-white/60">
+          <h2 className="text-xl font-bold text-gray-900">Flow in four steps</h2>
+          <ol className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 list-none p-0 m-0">
             {STEPS.map((s) => (
-              <div key={s.n} className="relative">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-rose-500 text-lg font-bold text-white mb-4">
+              <li key={s.n} className="rounded-xl border border-white/70 bg-white p-5 shadow-sm">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 text-sm font-bold text-white shadow mb-3">
                   {s.n}
                 </div>
-                <h3 className="font-bold text-lg mb-2">{s.title}</h3>
-                <p className="text-slate-400 text-sm">{s.desc}</p>
-              </div>
+                <h3 className="font-semibold text-gray-900 mb-1">{s.title}</h3>
+                <p className="text-gray-600 text-sm leading-relaxed">{s.desc}</p>
+              </li>
             ))}
-          </div>
-          <div className="mt-12 text-center">
-            <a
-              href="#create"
-              className="inline-block rounded-full bg-rose-500 px-8 py-4 text-base font-semibold text-white hover:bg-rose-600 transition"
-            >
-              Start Creating Manga Now →
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/* Final CTA */}
-      <section className="py-24 border-t border-slate-800">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <p className="text-rose-400/90 text-sm font-medium uppercase tracking-wider mb-4">
-            Complimentary Credits — No Payment Needed
-          </p>
-          <h2 className="text-3xl sm:text-4xl font-bold mb-6">
-            Ready to Become a Manga Creator?
-          </h2>
-          <p className="text-slate-400 text-lg mb-10">
-            Join the community of storytellers bringing their visions to life. Try free today —
-            artistic talent not required.
-          </p>
-          <div className="flex flex-wrap justify-center gap-8 mb-10 text-center">
-            {STATS.map((s) => (
-              <div key={s.label}>
-                <div className="text-2xl font-bold text-white">{s.value}</div>
-                <div className="text-slate-500 text-sm">{s.label}</div>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-wrap justify-center gap-4">
-            <a
-              href="#create"
-              className="rounded-full bg-rose-500 px-8 py-4 text-base font-semibold text-white hover:bg-rose-600 transition"
-            >
-              Start Creating Now
-            </a>
-            <a
-              href="#gallery"
-              className="rounded-full border border-slate-600 px-8 py-4 text-base font-medium text-slate-300 hover:border-slate-500 hover:text-white transition"
-            >
-              Browse Gallery
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/* Footer */}
-      <footer className="py-12 border-t border-slate-800">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-wrap justify-center gap-8 text-slate-500 text-sm">
-            <span>Try Before You Buy</span>
-            <span>60-90 Second Generation</span>
-            <span>High-Res Export</span>
-          </div>
-          <div className="mt-6 text-center">
-            <Link to="/" className="text-slate-500 hover:text-slate-400 text-sm">
-              ← Back to Comic Generator
-            </Link>
-          </div>
-        </div>
-      </footer>
-    </div>
+          </ol>
+        </section>
+      </div>
+    </PageShell>
   );
 }

--- a/frontend/src/pages/MangaAIPage.jsx
+++ b/frontend/src/pages/MangaAIPage.jsx
@@ -1,8 +1,17 @@
 import { Link } from 'react-router-dom';
 
 const NAV_LINKS = [
-  { label: 'Start Creating', href: '#create' },
-  { label: 'View Examples', href: '#gallery' },
+  { label: 'Start creating', href: '#create' },
+  { label: 'Examples', href: '#gallery' },
+];
+
+const PAGE_OUTLINE = [
+  { label: 'Ways to use the app', href: '#create' },
+  { label: 'Example ideas', href: '#gallery' },
+  { label: 'Styles', href: '#styles' },
+  { label: 'Who it is for', href: '#audience' },
+  { label: 'Highlights', href: '#features' },
+  { label: 'Steps', href: '#steps' },
 ];
 
 const BADGES = [
@@ -21,18 +30,20 @@ const GENRE_CHIPS = [
 
 const CREATION_METHODS = [
   {
-    title: 'Upload Your Characters',
+    title: 'Describe your story',
     description:
-      'Have photos of people or character designs? Upload them and our AI will transform them into manga characters, maintaining their unique features across all panels in authentic manga style.',
-    bullets: ['Perfect for OC manga', 'Manga-style expressions', 'Consistent character design'],
-    cta: 'Upload Characters',
+      'This project generates comics from text: you add a title and a story, pick a style preset and panel count, and the backend splits the text and requests one image per panel.',
+    bullets: ['Works in the Create page today', 'Captions and prompts stored per panel', 'Results depend on the configured image model'],
+    cta: 'Open Create',
+    to: '/comics/create',
   },
   {
-    title: 'Describe Your Story',
+    title: 'Browse finished comics',
     description:
-      "Just type your story or scene descriptions, and AI will generate everything - characters, backgrounds, and action sequences in authentic manga style.",
-    bullets: ['Authentic manga panels', 'AI-designed characters', 'No images needed'],
-    cta: 'Write Your Story',
+      'Every generated comic is listed under Comics with its cover thumbnail, style, and panel count. Open one to read panels in order and inspect captions.',
+    bullets: ['Grid of all your comics', 'Reading order is top to bottom', 'Optional prompt details per panel'],
+    cta: 'Open Comics',
+    to: '/comics',
   },
 ];
 
@@ -118,6 +129,24 @@ export default function MangaAIPage() {
         </div>
       </nav>
 
+      {/* Page outline — quick jumps */}
+      <div className="border-b border-slate-800 bg-slate-900/80 backdrop-blur">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-2">On this page</p>
+          <nav aria-label="Page sections" className="flex flex-wrap gap-x-4 gap-y-2">
+            {PAGE_OUTLINE.map((item) => (
+              <a
+                key={item.href}
+                href={item.href}
+                className="text-sm text-slate-400 hover:text-rose-300 transition border-b border-transparent hover:border-rose-400/60 pb-0.5"
+              >
+                {item.label}
+              </a>
+            ))}
+          </nav>
+        </div>
+      </div>
+
       {/* Hero */}
       <section className="relative overflow-hidden pt-16 pb-24 sm:pt-24 sm:pb-32">
         <div className="absolute inset-0 bg-gradient-to-b from-rose-950/20 via-transparent to-transparent" />
@@ -169,11 +198,11 @@ export default function MangaAIPage() {
       </section>
 
       {/* Two Ways to Create */}
-      <section id="create" className="py-20 border-t border-slate-800">
+      <section id="create" className="py-20 border-t border-slate-800 scroll-mt-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-center mb-4">Two Ways to Create Your Manga</h2>
+          <h2 className="text-3xl font-bold text-center mb-4">What you can do in this app</h2>
           <p className="text-slate-400 text-center max-w-2xl mx-auto mb-16">
-            Choose the creation method that works best for your manga story
+            The live product is the Create and Comics flows linked below—this page is an overview of the idea and positioning.
           </p>
           <div className="grid md:grid-cols-2 gap-8">
             {CREATION_METHODS.map((m) => (
@@ -182,20 +211,21 @@ export default function MangaAIPage() {
                 className="rounded-2xl border border-slate-800 bg-slate-900/50 p-8 hover:border-slate-700 transition"
               >
                 <h3 className="text-xl font-bold mb-4">{m.title}</h3>
-                <p className="text-slate-400 mb-6">{m.description}</p>
+                <p className="text-slate-400 mb-6 leading-relaxed">{m.description}</p>
                 <ul className="space-y-2 mb-8">
                   {m.bullets.map((b) => (
-                    <li key={b} className="flex items-center gap-2 text-slate-300">
-                      <span className="text-rose-500">•</span> {b}
+                    <li key={b} className="flex items-start gap-2 text-slate-300 text-sm leading-relaxed">
+                      <span className="text-rose-500 shrink-0 mt-0.5">•</span>
+                      <span>{b}</span>
                     </li>
                   ))}
                 </ul>
-                <a
-                  href="#create"
+                <Link
+                  to={m.to}
                   className="inline-block rounded-full bg-rose-500 px-5 py-2.5 text-sm font-medium text-white hover:bg-rose-600 transition"
                 >
                   {m.cta}
-                </a>
+                </Link>
               </div>
             ))}
           </div>
@@ -203,7 +233,7 @@ export default function MangaAIPage() {
       </section>
 
       {/* Gallery */}
-      <section id="gallery" className="py-20 border-t border-slate-800 bg-slate-900/30">
+      <section id="gallery" className="py-20 border-t border-slate-800 bg-slate-900/30 scroll-mt-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-center mb-4">Manga Created with Manga AI</h2>
           <p className="text-slate-400 text-center mb-12">
@@ -242,7 +272,7 @@ export default function MangaAIPage() {
       </section>
 
       {/* Choose Your Manga Style */}
-      <section className="py-20 border-t border-slate-800">
+      <section id="styles" className="py-20 border-t border-slate-800 scroll-mt-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-center mb-4">Choose Your Manga Style</h2>
           <p className="text-slate-400 text-center mb-12">
@@ -264,7 +294,7 @@ export default function MangaAIPage() {
       </section>
 
       {/* Perfect For */}
-      <section className="py-20 border-t border-slate-800 bg-slate-900/30">
+      <section id="audience" className="py-20 border-t border-slate-800 bg-slate-900/30 scroll-mt-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-center mb-4">Perfect For Every Manga Creator</h2>
           <p className="text-slate-400 text-center mb-12">
@@ -285,7 +315,7 @@ export default function MangaAIPage() {
       </section>
 
       {/* Why Choose */}
-      <section className="py-20 border-t border-slate-800">
+      <section id="features" className="py-20 border-t border-slate-800 scroll-mt-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-center mb-4">Why Choose Manga AI?</h2>
           <p className="text-slate-400 text-center mb-12">
@@ -306,7 +336,7 @@ export default function MangaAIPage() {
       </section>
 
       {/* 4 Steps */}
-      <section className="py-20 border-t border-slate-800 bg-slate-900/30">
+      <section id="steps" className="py-20 border-t border-slate-800 bg-slate-900/30 scroll-mt-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-center mb-4">Create Your Manga in 4 Simple Steps</h2>
           <p className="text-slate-400 text-center mb-12">


### PR DESCRIPTION
## Summary

End-to-end rework of the comic generator on top of the original AI scaffold:

- **AI engine (Hugging Face)** — `splitStoryIntoPanels` now returns `{ narration, scene }` per panel. `narration` is storybook prose shown to the reader; `scene` is the visual description fed to the image model. Chat prompt enforces continuous storytelling (panels read as one cohesive story); heuristic fallback never cuts mid-sentence and falls back to clause splits when sentences are sparse. Image prompt is composed with title + style + position + 400-char story excerpt + scene + character-consistency line + no-text guard. Multi-model + multi-provider fallback chain for both chat (`HF_CHAT_PROVIDER`) and image gen (`HF_IMAGE_MODEL` / `HF_IMAGE_PROVIDER`), with `HF_PANELS_CHAT=0` to skip chat entirely.
- **Unified app** — Folded the old separate "Manga AI" marketing page into `/guide` so the whole experience lives in one React Router app under one nav bar. Old `/manga-ai` route redirects.
- **Visual refresh** — New gradient background, sticky translucent nav with gradient logo badge, `PageShell` accent strip, gradient section headers in `SectionBlock`, gradient hero on home, gradient CTAs across Create/Comics/Detail pages.
- **Comic detail viewer** — Replaced the vertical stack of panels with a single-panel arrow-navigated carousel: ←/→ buttons, ←/→ keyboard nav, position dots, "Panel X of N" pill. Animated **book page-turn** transition (3D `rotateY` + `transform-origin` per direction, 600ms, respects `prefers-reduced-motion`). Image prompt hidden from reader; storybook narration rendered as a serif italic narration box under the image.
- **Library management** — Delete button on every comic card and on the comic detail page (with `confirm()` and post-delete redirect).
- **Home/Guide cleanup** — Removed the duplicated "create comic" hero on Home; removed unhelpful "Example story ideas" section from the Guide.
- **Header bug** — `Comics` no longer shows an active underline when on `/comics/create` (custom `useLocation`-driven active class).
- **Docs** — `backend/README.md` and `backend/.env.example` updated with HF provider setup, troubleshooting, and the new `HF_PANELS_CHAT` / `HF_CHAT_PROVIDER` / `HF_IMAGE_MODEL` / `HF_IMAGE_PROVIDER` knobs.

## Commits in this PR

- `99cb785` Refresh UI, add page-turn carousel, improve AI panel split with narration/scene
- `949a2aa` Improve UI layout: PageShell, sections, nav, Manga AI outline
- `2648da1` Update README files to reflect project name change and new features
- `7bc5005` feat: Hugging Face AI comic engine, Manga AI page, fix panel image loading
- `a02fd56` Implement AI comic generation feature and update API documentation

## Test plan

- [ ] `npm run dev` (root) starts both backend (`:3000`) and frontend (`:5173`) cleanly.
- [ ] Home `/` shows only the gradient hero (no duplicate "Create" hero); CTAs route to `/comics/create` and `/guide`.
- [ ] Header: clicking `Create` underlines only `Create`; clicking a comic detail does not underline `Create`.
- [ ] `/guide` renders without the Example Story Ideas section; `/manga-ai` redirects to `/guide`.
- [ ] Create a comic with `HUGGINGFACE_TOKEN` set: panels save to disk under `backend/uploads/comics/<id>/panel-N.png` and the comic appears in `/comics`.
- [ ] On `/comics/:id`: arrow buttons + ← / → keys turn pages; the page-turn animation plays in the correct direction; narration renders as italic serif under the image; no "Image prompt used" `<details>` is visible.
- [ ] Position dots jump to the right panel and animate in the correct direction (forward when index goes up, backward when it goes down).
- [ ] Delete from the Comics card and from the detail page both work, with confirm dialog and redirect.
- [ ] Setting `HF_PANELS_CHAT=0` in backend `.env` still produces a comic (heuristic split path) without errors.
- [ ] When chat fails mid-generation, server logs warn and continue with the heuristic fallback.

## Known follow-ups (not in this PR)

- HF Inference Provider monthly credit (~$0.10) is easy to deplete — image gen returns a budget error once exhausted. Plan to add Pollinations.ai as the first attempt in `buildImageAttempts` and Cloudflare Workers AI as a backup so the POC can keep running on $0.
- Per-panel "re-roll" endpoint + button to regenerate a single bad panel without redoing the whole comic.
- Heuristic or LLM-derived character sheet prepended to every image prompt for stronger cross-panel character consistency.

Made with [Cursor](https://cursor.com)